### PR TITLE
some config settings on API libs

### DIFF
--- a/src/SevenDigital.Api.Dynamic.Integration.Tests/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Dynamic.Integration.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -18,6 +18,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("1e17ed62-4df1-4599-9f93-73bffe77b22e")]

--- a/src/SevenDigital.Api.Dynamic.Integration.Tests/SevenDigital.Api.Dynamic.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Dynamic.Integration.Tests/SevenDigital.Api.Dynamic.Integration.Tests.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -39,9 +40,7 @@
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SevenDigital.Api.Dynamic.Unit.Tests/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Dynamic.Unit.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 

--- a/src/SevenDigital.Api.Dynamic.Unit.Tests/SevenDigital.Api.Dynamic.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Dynamic.Unit.Tests/SevenDigital.Api.Dynamic.Unit.Tests.csproj
@@ -37,9 +37,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SevenDigital.Api.Dynamic/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Dynamic/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -18,6 +18,9 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
+
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("e41bf581-4939-4ca3-a3f4-a6e1499d075b")]

--- a/src/SevenDigital.Api.Dynamic/SevenDigital.Api.Dynamic.csproj
+++ b/src/SevenDigital.Api.Dynamic/SevenDigital.Api.Dynamic.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -34,9 +35,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SevenDigital.Api.Schema.Unit.Tests/SevenDigital.Api.Schema.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Schema.Unit.Tests/SevenDigital.Api.Schema.Unit.Tests.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/SevenDigital.Api.Schema/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Schema/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -20,6 +20,7 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 
 [assembly: ComVisible(false)]
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 

--- a/src/SevenDigital.Api.Schema/SevenDigital.Api.Schema.csproj
+++ b/src/SevenDigital.Api.Schema/SevenDigital.Api.Schema.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/SevenDigital.Api.Wrapper.ExampleUsage/SevenDigital.Api.Wrapper.ExampleUsage.csproj
+++ b/src/SevenDigital.Api.Wrapper.ExampleUsage/SevenDigital.Api.Wrapper.ExampleUsage.csproj
@@ -39,6 +39,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -21,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/SevenDigital.Api.Wrapper/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Wrapper/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
@@ -18,6 +19,8 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("3809d7e0-cd2a-4017-8b6e-1ed2365f70cf")]

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/WP7/SevenDigital.Api.Schema/Properties/AssemblyInfo.cs
+++ b/src/WP7/SevenDigital.Api.Schema/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -18,6 +18,9 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
+
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("4d0cf795-251b-46b7-903e-b48c4bc737a4")]

--- a/src/WP7/SevenDigital.Api.Wrapper/Properties/AssemblyInfo.cs
+++ b/src/WP7/SevenDigital.Api.Wrapper/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System;
+using System.Reflection;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -18,6 +18,9 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
+
+[assembly: CLSCompliant(true)]
+
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ac15fe28-db72-44e5-a15a-c5bc142c12b9")]


### PR DESCRIPTION
To make life easier for some consumers of the API, marked the libs as CLSCompliant(true)
Turned on warnings as errors on libs and tests
Removed some unnneeded refs to System.Data
