### PR TITLE
OAuth API: Rename UserSecret to TokenSecret

### DIFF
--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/EndPointInfo.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/EndPointInfo.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿
+using System;
+using System.Collections.Generic;
 
 namespace SevenDigital.Api.Wrapper.EndpointResolution
 {
@@ -16,7 +18,10 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution
 
 		public string UserToken { get; set; }
 
-		public string UserSecret { get; set; }
+		public string TokenSecret { get; set; }
+
+		[Obsolete("Use TokenSecret")]
+		public string UserSecret { get { return TokenSecret; } set { TokenSecret = value; } }
 
 		public bool IsSigned { get; set; }
 

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/OAuth/IUrlSigner.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/OAuth/IUrlSigner.cs
@@ -5,8 +5,8 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.OAuth
 {
 	public interface IUrlSigner 
 	{
-		Uri SignUrl(string urlWithParameters, string userToken, string userSecret, IOAuthCredentials consumerCredentials);
-		string SignGetUrl(string urlWithParameters, string userToken, string userSecret, IOAuthCredentials consumerCredentials);
-		IDictionary<string, string> SignPostRequest(string url, string userToken, string userSecret, IOAuthCredentials consumerCredentials, Dictionary<string, string> postParameters);
+		Uri SignUrl(string urlWithParameters, string userToken, string tokenSecret, IOAuthCredentials consumerCredentials);
+		string SignGetUrl(string urlWithParameters, string userToken, string tokenSecret, IOAuthCredentials consumerCredentials);
+		IDictionary<string, string> SignPostRequest(string url, string userToken, string tokenSecret, IOAuthCredentials consumerCredentials, Dictionary<string, string> postParameters);
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/OAuth/UrlSigner.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/OAuth/UrlSigner.cs
@@ -18,9 +18,8 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.OAuth
 		/// the Uri into a string, it unescapes the oauth signature and if it contains '+' characters
 		/// it will fail.
 		/// </summary>
-		public string SignGetUrl(string urlWithParameters, string userToken, string userSecret, IOAuthCredentials consumerCredentials)
+		public string SignGetUrl(string urlWithParameters, string userToken, string tokenSecret, IOAuthCredentials consumerCredentials)
 		{
-			
 			var timeStamp = _oAuthBase.GenerateTimeStamp();
 			var nonce = _oAuthBase.GenerateNonce();
 
@@ -30,7 +29,7 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.OAuth
 				consumerCredentials.ConsumerKey,
 				consumerCredentials.ConsumerSecret,
 				userToken,
-				userSecret,
+				tokenSecret,
 				"GET",
 				timeStamp,
 				nonce,
@@ -42,12 +41,12 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.OAuth
 			return string.Format("{0}?{1}&oauth_signature={2}", normalizedUrl, normalizedRequestParameters, encodedSignature);
 		}
 
-		public Uri SignUrl(string urlWithParameters, string userToken, string userSecret, IOAuthCredentials consumerCredentials)
+		public Uri SignUrl(string urlWithParameters, string userToken, string tokenSecret, IOAuthCredentials consumerCredentials)
 		{
-			return new Uri(SignGetUrl(urlWithParameters, userToken, userSecret, consumerCredentials));
+			return new Uri(SignGetUrl(urlWithParameters, userToken, tokenSecret, consumerCredentials));
 		}
 
-		public IDictionary<string, string> SignPostRequest(string url, string userToken, string userSecret, 
+		public IDictionary<string, string> SignPostRequest(string url, string userToken, string tokenSecret,
 			IOAuthCredentials consumerCredentials, Dictionary<string, string> postParameters)
 		{
 			if (string.IsNullOrEmpty(consumerCredentials.ConsumerKey))
@@ -63,7 +62,7 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.OAuth
 			string normalizedUrl;
 			
 			var signature = _oAuthBase.GenerateSignature(new Uri(url), consumerCredentials.ConsumerKey, 
-				consumerCredentials.ConsumerSecret, userToken, userSecret, "POST", timestamp, nonce, 
+				consumerCredentials.ConsumerSecret, userToken, tokenSecret, "POST", timestamp, nonce,
 				out normalizedUrl, out normalizedRequestParameters, postParameters);
 
 			var parameters = new Dictionary<string, string>(postParameters)

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/GetRequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/GetRequestHandler.cs
@@ -40,11 +40,10 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 		{
 			if (endPointInfo.IsSigned)
 			{
-				return _urlSigner.SignGetUrl(uri, endPointInfo.UserToken, endPointInfo.UserSecret, _oAuthCredentials);
+				return _urlSigner.SignGetUrl(uri, endPointInfo.UserToken, endPointInfo.TokenSecret, _oAuthCredentials);
 			}
 			return uri;
 		}
-
 
 		protected override string AdditionalParameters(Dictionary<string, string> newDictionary)
 		{

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/PostRequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/PostRequestHandler.cs
@@ -39,7 +39,7 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 		{
 			if (endPointInfo.IsSigned)
 			{
-				return _urlSigner.SignPostRequest(uri, endPointInfo.UserToken, endPointInfo.UserSecret, _oAuthCredentials, endPointInfo.Parameters);
+				return _urlSigner.SignPostRequest(uri, endPointInfo.UserToken, endPointInfo.TokenSecret, _oAuthCredentials, endPointInfo.Parameters);
 			}
 			return endPointInfo.Parameters;
 		}

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using SevenDigital.Api.Schema.OAuth;
@@ -102,7 +102,7 @@ namespace SevenDigital.Api.Wrapper
 		public virtual IFluentApi<T> ForUser(string token, string secret)
 		{
 			_endPointInfo.UserToken = token;
-			_endPointInfo.UserSecret = secret;
+			_endPointInfo.TokenSecret = secret;
 			return this;
 		}
 


### PR DESCRIPTION
"UserSecret" is a badly named parameter. The real name (as specified in
our documentation) is TokenSecret, because it's a secret related to the
token, not to the user.

This makes the API a bit less confusing :)
