### PR TITLE
Refactoring around ApiException: try to make it less mutable

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Exceptions/ExceptionFactoryTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Exceptions/ExceptionFactoryTests.cs
@@ -15,7 +15,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Exceptions
 		public void Should_set_properties_when_creating_unrecognised_status_exception()
 		{
 			var dummyResponse = new Response() {Body = "Test Body", StatusCode = HttpStatusCode.BadRequest};
-			var result = ExceptionFactory.CreateUnrecognisedStatusException(dummyResponse);
+			var result = new UnrecognisedStatusException(dummyResponse);
 
 			Assert.That(result.ResponseBody, Is.EqualTo(dummyResponse.Body));
 			Assert.That(result.StatusCode, Is.EqualTo(dummyResponse.StatusCode));
@@ -26,7 +26,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Exceptions
 		{
 			var dummyResponse = new Response() {Body = "Test Body", StatusCode = HttpStatusCode.BadRequest};
 			var innerException = new Exception();
-			var result = ExceptionFactory.CreateUnrecognisedErrorException(dummyResponse, innerException);
+			var result = new UnrecognisedErrorException(innerException, dummyResponse);
 
 			Assert.That(result.ResponseBody, Is.EqualTo(dummyResponse.Body));
 			Assert.That(result.StatusCode, Is.EqualTo(dummyResponse.StatusCode));
@@ -39,7 +39,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Exceptions
 		{
 			var dummyResponse = new Response() { Body = "Test Body", StatusCode = HttpStatusCode.BadRequest };
 			var innerException = new Exception();
-			var result = ExceptionFactory.CreateUnrecognisedErrorException(dummyResponse, innerException);
+			var result = new UnrecognisedErrorException(innerException, dummyResponse);
 
 			Assert.That(result.ResponseBody, Is.EqualTo(dummyResponse.Body));
 			Assert.That(result.StatusCode, Is.EqualTo(dummyResponse.StatusCode));
@@ -61,7 +61,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Exceptions
 		public void Should_set_properties_when_creating_oauth_exception()
 		{
 			var dummyResponse = new Response() { Body = "Test Body", StatusCode = HttpStatusCode.BadRequest };
-			var result = ExceptionFactory.CreateOAuthException(dummyResponse);
+			var result = new OAuthException(dummyResponse);
 
 			Assert.That(result.ResponseBody, Is.EqualTo(dummyResponse.Body));
 			Assert.That(result.StatusCode, Is.EqualTo(dummyResponse.StatusCode));

--- a/src/SevenDigital.Api.Wrapper/Exceptions/ApiErrorException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/ApiErrorException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Schema;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -11,9 +13,10 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		protected ApiErrorException(string message)
-			: base(message)
+		protected ApiErrorException(string message, Response response, Error error)
+			: base(message, response)
 		{
+			ErrorCode = error.Code;
 		}
 
 		protected ApiErrorException(string message, Exception innerException)

--- a/src/SevenDigital.Api.Wrapper/Exceptions/ApiException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/ApiException.cs
@@ -1,14 +1,15 @@
 using System;
 using System.Net;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
 	public abstract class ApiException : Exception
 	{
 		public string Uri { get; set; }
-		public HttpStatusCode StatusCode { get; set; }
-		public string ResponseBody { get; set; }
+		public HttpStatusCode StatusCode { get; private set; }
+		public string ResponseBody { get; private set; }
 
 		protected ApiException()
 		{
@@ -22,6 +23,20 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		protected ApiException(string message, Exception innerException)
 			: base(message, innerException)
 		{
+		}
+
+		protected ApiException(string message, Exception innerException, Response response)
+			: base(message, innerException)
+		{
+			ResponseBody = response.Body;
+			StatusCode = response.StatusCode;
+		}
+
+		protected ApiException(string message, Response response)
+			: base(message)
+		{
+			ResponseBody = response.Body;
+			StatusCode = response.StatusCode;
 		}
 
 		protected ApiException(SerializationInfo info, StreamingContext context)

--- a/src/SevenDigital.Api.Wrapper/Exceptions/InputParameterException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/InputParameterException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Schema;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -11,8 +13,8 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public InputParameterException(string message)
-			: base(message)
+		public InputParameterException(string message, Response response, Error error)
+			: base(message, response, error)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/InvalidResourceException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/InvalidResourceException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Schema;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -11,8 +13,8 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public InvalidResourceException(string message)
-			: base(message)
+		public InvalidResourceException(string message, Response response, Error error)
+			: base(message, response, error)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/NonXmlResponseException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/NonXmlResponseException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -13,13 +14,18 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
+		public NonXmlResponseException(Response response)
+			: base(DEFAULT_ERROR_MESSAGE, response)
+		{
+		}
+
 		public NonXmlResponseException(string message)
 			: base(message)
 		{
 		}
 
-		public NonXmlResponseException(string message, Exception innerException)
-			: base(message, innerException)
+		public NonXmlResponseException(string message, Exception innerException, Response response)
+			: base(message, innerException, response)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/OAuthException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/OAuthException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -13,6 +14,10 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 
 		public OAuthException(string message)
 			: base(message)
+		{
+		}
+
+		public OAuthException(Response response) : base (response.Body, response)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/RemoteApiException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/RemoteApiException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Schema;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -11,8 +13,8 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public RemoteApiException(string message)
-			: base(message)
+		public RemoteApiException(string message, Response response, Error error)
+			: base(message, response, error)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedErrorException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedErrorException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -13,13 +14,23 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public UnrecognisedErrorException(string message)
-			: base(message)
+		public UnrecognisedErrorException(Exception innerException, Response response)
+			: base(DEFAULT_ERROR_MESSAGE, innerException, response)
+		{
+		}
+
+		public UnrecognisedErrorException(string message, Response response)
+			: base(message, response)
 		{
 		}
 
 		public UnrecognisedErrorException(string message, Exception innerException)
 			: base(message, innerException)
+		{
+		}
+
+		public UnrecognisedErrorException(string message, Exception innerException, Response response)
+			: base(message, innerException, response)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedStatusException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedStatusException.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -10,6 +11,11 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 
 		public UnrecognisedStatusException()
 			: base(DEFAULT_ERROR_MESSAGE)
+		{
+		}
+
+		public UnrecognisedStatusException(Response response)
+			: base(DEFAULT_ERROR_MESSAGE, response)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Exceptions/UserCardException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/UserCardException.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
+using SevenDigital.Api.Schema;
+using SevenDigital.Api.Wrapper.Utility.Http;
 
 namespace SevenDigital.Api.Wrapper.Exceptions
 {
@@ -11,8 +13,8 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public UserCardException(string message)
-			: base(message)
+		public UserCardException(string message, Response response, Error error)
+			: base(message, response, error)
 		{
 		}
 

--- a/src/SevenDigital.Api.Wrapper/Utility/Serialization/ExceptionFactory.cs
+++ b/src/SevenDigital.Api.Wrapper/Utility/Serialization/ExceptionFactory.cs
@@ -12,64 +12,26 @@ namespace SevenDigital.Api.Wrapper.Utility.Serialization
 			ApiErrorException apiException;
 			if (error.Code >= 1000 && error.Code < 2000)
 			{
-				apiException = new InputParameterException(error.ErrorMessage);
+				apiException = new InputParameterException(error.ErrorMessage, response, error);
 			}
 			else if (error.Code >= 2000 && error.Code < 3000)
 			{
-				apiException = new InvalidResourceException(error.ErrorMessage);
+				apiException = new InvalidResourceException(error.ErrorMessage, response, error);
 			}
 			else if (error.Code >= 3000 && error.Code < 4000)
 			{
-				apiException = new UserCardException(error.ErrorMessage);
+				apiException = new UserCardException(error.ErrorMessage, response, error);
 			}
 			else if ((error.Code >= 7000 && error.Code < 8000) || (error.Code >= 9000 && error.Code < 10000))
 			{
-				apiException = new RemoteApiException(error.ErrorMessage);
+				apiException = new RemoteApiException(error.ErrorMessage, response, error);
 			}
 			else
 			{
-				var unrecognisedErrorException = new UnrecognisedErrorException(error.ErrorMessage);
-				PopulateStatusAndBodyFromResponse(response, unrecognisedErrorException);
-				throw unrecognisedErrorException;
+				throw new UnrecognisedErrorException(error.ErrorMessage, response);
 			}
 
-			PopulateStatusAndBodyFromResponse(response, apiException);
-			apiException.ErrorCode = error.Code;
 			return apiException;
-		}
-
-		public static NonXmlResponseException CreateNonXmlResponseException(Response response)
-		{
-			var nonXmlResponseException = new NonXmlResponseException();
-			PopulateStatusAndBodyFromResponse(response, nonXmlResponseException); 
-			return nonXmlResponseException;
-		}
-
-		public static UnrecognisedStatusException CreateUnrecognisedStatusException(Response response)
-		{
-			var unrecognisedStatus = new UnrecognisedStatusException();
-			PopulateStatusAndBodyFromResponse(response, unrecognisedStatus);
-			return unrecognisedStatus;
-		}
-
-		public static UnrecognisedErrorException CreateUnrecognisedErrorException(Response response, Exception ex)
-		{
-			var unrecognisedErrorException = new UnrecognisedErrorException(UnrecognisedErrorException.DEFAULT_ERROR_MESSAGE, ex);
-			PopulateStatusAndBodyFromResponse(response, unrecognisedErrorException);
-			return unrecognisedErrorException;
-		}
-
-		public static OAuthException CreateOAuthException(Response response)
-		{
-			var oAuthException = new OAuthException(response.Body);
-			PopulateStatusAndBodyFromResponse(response, oAuthException);
-			return oAuthException;
-		}
-
-		private static void PopulateStatusAndBodyFromResponse(Response response, ApiException apiException)
-		{
-			apiException.StatusCode = response.StatusCode;
-			apiException.ResponseBody = response.Body;
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Utility/Serialization/ResponseParser.cs
+++ b/src/SevenDigital.Api.Wrapper/Utility/Serialization/ResponseParser.cs
@@ -33,13 +33,13 @@ namespace SevenDigital.Api.Wrapper.Utility.Serialization
 				throw new ArgumentNullException("response");
 
 			if (string.IsNullOrEmpty(response.Body))
-				throw ExceptionFactory.CreateNonXmlResponseException(response);
+				throw new NonXmlResponseException(response);
 
 			if (!_apiResponseDetector.IsXml(response.Body))
 				DetectAndThrowForNonXmlResponses(response);
 
 			if (!_apiResponseDetector.IsApiOkResponse(response.Body) && !_apiResponseDetector.IsApiErrorResponse(response.Body))
-				throw ExceptionFactory.CreateUnrecognisedStatusException(response);
+				throw new UnrecognisedStatusException(response);
 
 			if (_apiResponseDetector.IsApiOkResponse(response.Body) && !_apiResponseDetector.IsApiErrorResponse(response.Body))
 				return;
@@ -51,9 +51,9 @@ namespace SevenDigital.Api.Wrapper.Utility.Serialization
 		private void DetectAndThrowForNonXmlResponses(Response response)
 		{
 			if (_apiResponseDetector.IsOAuthError(response.Body))
-				throw ExceptionFactory.CreateOAuthException(response);
+				throw new OAuthException(response);
 
-			throw ExceptionFactory.CreateNonXmlResponseException(response);
+			throw new NonXmlResponseException(response);
 		}
 
 		private Error ParseError(Response response)
@@ -74,7 +74,7 @@ namespace SevenDigital.Api.Wrapper.Utility.Serialization
 			}
 			catch(Exception ex)
 			{
-				throw ExceptionFactory.CreateUnrecognisedErrorException(response, ex);
+				throw new UnrecognisedErrorException(ex, response);
 			}
 		}
 
@@ -93,10 +93,7 @@ namespace SevenDigital.Api.Wrapper.Utility.Serialization
 			}
 			catch (Exception ex)
 			{
-				var nonXmlResponseException = new NonXmlResponseException(NonXmlResponseException.DEFAULT_ERROR_MESSAGE, ex);
-				nonXmlResponseException.ResponseBody = response.Body;
-				nonXmlResponseException.StatusCode = response.StatusCode;
-				throw nonXmlResponseException;
+				throw new NonXmlResponseException(NonXmlResponseException.DEFAULT_ERROR_MESSAGE, ex, response);
 			}
 		}
 	}


### PR DESCRIPTION
This neat refactoring makes the code a bit more simple by
- making the ApiException responsible of assigning itself the properties
  (=> private setters, more immutable)
- removing the methods PopulateStatusAndBodyFromResponse (mutability smell)
  and Create*Exception ones (IoC smell).

I know I could go a bit further and user more interfaces instead of concrete
implementations, but with this change we're in a better place than before.

This is some cleanup before I propose another pull request about
exception messages.
