### PR TITLE
Api copy threadsafe demo

### DIFF
--- a/src/SevenDigital.Api.Wrapper.ExampleUsage/App.config
+++ b/src/SevenDigital.Api.Wrapper.ExampleUsage/App.config
@@ -4,4 +4,4 @@
 		<add key="Wrapper.ConsumerKey" value="YOUR_KEY_HERE"/>
 		<add key="Wrapper.ConsumerSecret" value=""/>
 	</appSettings>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/></startup></configuration>

--- a/src/SevenDigital.Api.Wrapper.ExampleUsage/Program.cs
+++ b/src/SevenDigital.Api.Wrapper.ExampleUsage/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using SevenDigital.Api.Schema.ReleaseEndpoint;
 using SevenDigital.Api.Wrapper.Exceptions;
 using SevenDigital.Api.Schema.ArtistEndpoint;
@@ -54,6 +55,19 @@ namespace SevenDigital.Api.Wrapper.ExampleUsage
 
 			Console.WriteLine("Artist Search on \"{0}\" returns: {1} items", searchValue, artistSearch.TotalItems);
 			Console.WriteLine();
+
+			// -- artist/search parallel
+			var artistSearchTemplate = Api<ArtistSearch>.Create;
+
+			Parallel.For(1, 10, i =>
+				{
+					var result = artistSearchTemplate.NewInstance()
+						.WithQuery("keane")
+						.WithPageNumber(i)
+						.WithPageSize(1)
+						.Please();
+				Console.WriteLine(i + " >> " + result.Results.First().Artist.Name);
+			});
 
 			// -- release/search
 			var releaseSearch = Api<ReleaseSearch>.Create

--- a/src/SevenDigital.Api.Wrapper.ExampleUsage/SevenDigital.Api.Wrapper.ExampleUsage.csproj
+++ b/src/SevenDigital.Api.Wrapper.ExampleUsage/SevenDigital.Api.Wrapper.ExampleUsage.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SevenDigital.Api.Wrapper.ExampleUsage</RootNamespace>
     <AssemblyName>SevenDigital.Api.Wrapper.ExampleUsage</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -112,6 +112,11 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		}
 
+		public virtual IFluentApi<T> NewInstance()
+		{
+			return new FluentApi<T>(_requestCoordinator);
+		}
+
 		public virtual T Please()
 		{
 			try

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -17,5 +17,7 @@ namespace SevenDigital.Api.Wrapper
 
 		T Please();
 		void PleaseAsync(Action<T> callback);
+
+		IFluentApi<T> NewInstance();
 	}
 }


### PR DESCRIPTION
Here is another pull request that should not be merged but demonstrates an approach to making the API thread-safe.

The advantages of this idea are that it is really simple; there are about 5 lines of code added, and existing single-threaded code doesn't need to change at all.

The disadvantage is that new parallel code has to call a "NewInstance()" method on the IFluentApi that is similar to what Api.Create does. And you have to use it at just the right time.

Initially this method was called "Clone()" but I changed that, as the name "Clone" gave the impression that it copied the entire state, and that it could/should happen on every fluent operation. But it doesn't bother to copy the state - it just makes a new api instance that a thread can configure with the usual fluent methods. Do not call it after any fluent methods or the current state will be discarded.

A fill-blown state-copying clone could be done, but is a lot more code.
