### PR TITLE
Exceptions: Include Headers property in ApiException

### DIFF
--- a/src/SevenDigital.Api.Wrapper/Exceptions/ApiException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/ApiException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net;
 using System.Runtime.Serialization;
 using SevenDigital.Api.Wrapper.Http;
@@ -10,6 +11,7 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		public string Uri { get; internal set; }
 		public HttpStatusCode StatusCode { get; private set; }
 		public string ResponseBody { get; private set; }
+		public IDictionary<string, string> Headers { get; private set; }
 
 		protected ApiException()
 		{
@@ -29,6 +31,7 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 			: base(message, innerException)
 		{
 			ResponseBody = response.Body;
+			Headers = response.Headers;
 			StatusCode = response.StatusCode;
 		}
 
@@ -36,6 +39,7 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 			: base(message)
 		{
 			ResponseBody = response.Body;
+			Headers = response.Headers;
 			StatusCode = response.StatusCode;
 		}
 


### PR DESCRIPTION
For debugging purposes, headers are useful (in case, you need for example
to inspect 'X-7d-sys-origin'?

I have been conservative in this change because otherwise I would maybe break WebTeams usage :)

What I mean, specifically:
- Now that ApiException has all 3 properties from the Response class, maybe we should just store the Response object as a property! But not sure WebTeam likes this because it increasis coupling.
- We should remove the Response ctor that takes no Headers parameter, just in case it is misused (right now it's only used for tests, but tests could just use the full ctor and pass a null or empty IDictionary).

Let me know what you think.
Thanks
