### PR TITLE
Exceptions: remove all ctors that don't receive a Response

### DIFF
--- a/src/SevenDigital.Api.Wrapper/Exceptions/ApiErrorException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/ApiErrorException.cs
@@ -25,11 +25,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 			ErrorCode = errorCode;
 		}
 
-		protected ApiErrorException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected ApiErrorException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/ApiException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/ApiException.cs
@@ -22,11 +22,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		protected ApiException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected ApiException(string message, Exception innerException, Response response)
 			: base(message, innerException)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/InputParameterException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/InputParameterException.cs
@@ -23,11 +23,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public InputParameterException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected InputParameterException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/InvalidResourceException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/InvalidResourceException.cs
@@ -23,11 +23,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public InvalidResourceException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected InvalidResourceException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/OAuthException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/OAuthException.cs
@@ -22,11 +22,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public OAuthException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected OAuthException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/RemoteApiException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/RemoteApiException.cs
@@ -23,11 +23,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public RemoteApiException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected RemoteApiException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedErrorException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedErrorException.cs
@@ -24,11 +24,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public UnrecognisedErrorException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		public UnrecognisedErrorException(string message, Exception innerException, Response response)
 			: base(message, innerException, response)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedStatusException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/UnrecognisedStatusException.cs
@@ -24,11 +24,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public UnrecognisedStatusException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected UnrecognisedStatusException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{

--- a/src/SevenDigital.Api.Wrapper/Exceptions/UserCardException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/UserCardException.cs
@@ -23,11 +23,6 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 		{
 		}
 
-		public UserCardException(string message, Exception innerException)
-			: base(message, innerException)
-		{
-		}
-
 		protected UserCardException(SerializationInfo info, StreamingContext context)
 			: base(info, context)
 		{


### PR DESCRIPTION
Everytime an ApiException is instantiated, the Response should be passed
in, to have enough debugging details. Having a null response in an
ApiException is unacceptable, so let's rather forbid it at compile time.
