### PR TITLE
Move attribute validation logic out of FluentApi and into separate class...

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/AttributeManagement/AttributeRequestDataBuilderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/AttributeManagement/AttributeRequestDataBuilderTests.cs
@@ -6,13 +6,13 @@ using SevenDigital.Api.Wrapper.AttributeManagement;
 namespace SevenDigital.Api.Wrapper.Unit.Tests.AttributeManagement
 {
 	[TestFixture]
-	public class AttributeValidationTests
+	public class AttributeRequestDataBuilderTests
 	{
 		[Test]
 		public void Sets_correct_uri_based_on_apiEndpoint()
 		{
-			var attributeValidation = new AttributeValidation<StubEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.UriPath, Is.EqualTo("me/endpoint"));
 		}
@@ -20,8 +20,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.AttributeManagement
 		[Test]
 		public void Sets_IsSigned_if_OAuthSigned_specified()
 		{
-			var attributeValidation = new AttributeValidation<StubSecureEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubSecureEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.IsSigned);
 		}
@@ -29,8 +29,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.AttributeManagement
 		[Test]
 		public void Sets_IsSigned_false_if_OAuthSigned_not_specified()
 		{
-			var attributeValidation = new AttributeValidation<StubEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.IsSigned, Is.False);
 		}
@@ -38,8 +38,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.AttributeManagement
 		[Test]
 		public void Sets_UseHttps_if_RequireSecure_specified()
 		{
-			var attributeValidation = new AttributeValidation<StubSecureEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubSecureEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.UseHttps);
 		}
@@ -47,31 +47,30 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.AttributeManagement
 		[Test]
 		public void Sets_UseHttps_false_if_RequireSecure_not_specified()
 		{
-			var attributeValidation = new AttributeValidation<StubEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.UseHttps, Is.False);
 		}
 
 		[Test]
-		public void Sets_Httpethod_to_POST_if_HttpPost_specified()
+		public void Sets_HttpMethod_to_POST_if_HttpPost_specified()
 		{
-			var attributeValidation = new AttributeValidation<StubPostEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubPostEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.HttpMethod, Is.EqualTo("POST"));
 		}
 
 		[Test]
-		public void Httpethod_tdefaults_to_GET_if_HttpPost_not_specified()
+		public void HttpMethod_defaults_to_GET_if_HttpPost_not_specified()
 		{
-			var attributeValidation = new AttributeValidation<StubEndpoint>();
-			var requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
+			var requestData = attributeValidation.BuildRequestData();
 
 			Assert.That(requestData.HttpMethod, Is.EqualTo("GET"));
 		}
 	}
-
 
 	[ApiEndpoint("me/secure/endpoint")]
 	[OAuthSigned]

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <Compile Include="ApiUri.cs" />
     <Compile Include="AppSettingsCredentials.cs" />
-    <Compile Include="AttributeManagement\AttributeValidationTest.cs" />
+    <Compile Include="AttributeManagement\AttributeRequestDataBuilderTests.cs" />
     <Compile Include="BasketEndpoint\BasketEndpointTests.cs" />
     <Compile Include="Deserialisation\Payment\CardTypesTests.cs" />
     <Compile Include="Deserialisation\User\Payment\Cards_unit_tests.cs" />

--- a/src/SevenDigital.Api.Wrapper/AttributeManagement/AttributeRequestDataBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/AttributeManagement/AttributeRequestDataBuilder.cs
@@ -6,9 +6,9 @@ using SevenDigital.Api.Wrapper.Http;
 
 namespace SevenDigital.Api.Wrapper.AttributeManagement
 {
-	public class AttributeValidation<T>
+	public class AttributeRequestDataBuilder<T>
 	{
-		public RequestData Validate()
+		public RequestData BuildRequestData()
 		{
 			var requestData = new RequestData();
 

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -17,8 +17,8 @@ namespace SevenDigital.Api.Wrapper
 
 		public FluentApi(IRequestCoordinator requestCoordinator)
 		{
-			var attributeValidation = new AttributeValidation<T>();
-			_requestData = attributeValidation.Validate();
+			var attributeValidation = new AttributeRequestDataBuilder<T>();
+			_requestData = attributeValidation.BuildRequestData();
 
 			_requestCoordinator = requestCoordinator;
 

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Api.cs" />
-    <Compile Include="AttributeManagement\AttributeValidation.cs" />
+    <Compile Include="AttributeManagement\AttributeRequestDataBuilder.cs" />
     <Compile Include="EndpointResolution\AppDomainAssemblyResolver.cs" />
     <Compile Include="EndpointResolution\EssentialDependencyCheck.cs" />
     <Compile Include="EndpointResolution\RequestHandlers\GetRequestHandler.cs" />


### PR DESCRIPTION
This also moves the instantiation of the RequestData object into AttributeValidation as its now this that provides the initial requestdata setup.

Keeping it simple at the moment, have started to separate the attribute code into private methods and the AttributeValidation class is instatiated with the FluentApi ctor for the time being, but
makes the ctor much cleaner and could be added to in the future
