### PR TITLE
Separate IFluentApi in two: generic and non-generic

### DIFF
--- a/src/SevenDigital.Api.Wrapper/IApiEndpoint.cs
+++ b/src/SevenDigital.Api.Wrapper/IApiEndpoint.cs
@@ -1,0 +1,8 @@
+﻿
+namespace SevenDigital.Api.Wrapper
+{
+	public interface IApiEndpoint
+	{
+		string EndpointUrl { get; }
+	}
+}

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -5,7 +5,7 @@ namespace SevenDigital.Api.Wrapper
 {
 	// [AD] DO NOT PUT THE OUR BACK IN, NOT SUPPORTED IN WINDOWS PHONE
 	// ReSharper disable TypeParameterCanBeVariant
-	public interface IFluentApi<T>
+	public interface IFluentApi<T> : IApiEndpoint
 	// ReSharper restore TypeParameterCanBeVariant
 	{
 		IFluentApi<T> WithParameter(string key, string value);
@@ -13,7 +13,6 @@ namespace SevenDigital.Api.Wrapper
 		IFluentApi<T> ForUser(string token, string secret);
 		IFluentApi<T> WithEndpoint(string endpoint);
 		IFluentApi<T> UsingClient(IHttpClient httpClient);
-		string EndpointUrl { get; }
 
 		T Please();
 		void PleaseAsync(Action<T> callback);

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Extensions\HasUserDeliverItemParameterExtensions.cs" />
     <Compile Include="Extensions\LockerSortColumn.cs" />
     <Compile Include="Extensions\SortOrder.cs" />
+    <Compile Include="IApiEndpoint.cs" />
     <Compile Include="IApiUri.cs" />
     <Compile Include="IOAuthCredentials.cs" />
     <Compile Include="EndpointResolution\OAuth\IUrlSigner.cs" />


### PR DESCRIPTION
This allows us (lockerTeam) to abstract a bit more exception handling code.
