### PR TITLE
Split RequestData responsibilities

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/AttributeManagement/AttributeRequestDataBuilderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/AttributeManagement/AttributeRequestDataBuilderTests.cs
@@ -11,64 +11,64 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.AttributeManagement
 		[Test]
 		public void Sets_correct_uri_based_on_apiEndpoint()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.UriPath, Is.EqualTo("me/endpoint"));
+			Assert.That(endpointContext.UriPath, Is.EqualTo("me/endpoint"));
 		}
 
 		[Test]
 		public void Sets_IsSigned_if_OAuthSigned_specified()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubSecureEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubSecureEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.IsSigned);
+			Assert.That(endpointContext.IsSigned);
 		}
 
 		[Test]
 		public void Sets_IsSigned_false_if_OAuthSigned_not_specified()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.IsSigned, Is.False);
+			Assert.That(endpointContext.IsSigned, Is.False);
 		}
 
 		[Test]
 		public void Sets_UseHttps_if_RequireSecure_specified()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubSecureEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubSecureEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.UseHttps);
+			Assert.That(endpointContext.UseHttps);
 		}
 
 		[Test]
 		public void Sets_UseHttps_false_if_RequireSecure_not_specified()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.UseHttps, Is.False);
+			Assert.That(endpointContext.UseHttps, Is.False);
 		}
 
 		[Test]
 		public void Sets_HttpMethod_to_POST_if_HttpPost_specified()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubPostEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubPostEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.HttpMethod, Is.EqualTo("POST"));
+			Assert.That(endpointContext.HttpMethod, Is.EqualTo("POST"));
 		}
 
 		[Test]
 		public void HttpMethod_defaults_to_GET_if_HttpPost_not_specified()
 		{
-			var attributeValidation = new AttributeRequestDataBuilder<StubEndpoint>();
-			var requestData = attributeValidation.BuildRequestData();
+			var attributeValidation = new AttributeEndpointContextBuilder<StubEndpoint>();
+			var endpointContext = attributeValidation.BuildRequestData();
 
-			Assert.That(requestData.HttpMethod, Is.EqualTo("GET"));
+			Assert.That(endpointContext.HttpMethod, Is.EqualTo("GET"));
 		}
 	}
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/EndpointResolution/EndpointResolverTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/EndpointResolution/EndpointResolverTests.cs
@@ -29,16 +29,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 		[Test]
 		public void should_substitue_route_parameters()
 		{
-			var requestData = new RequestData
+			var endpointContext = new EndpointContext
 			{
 				UriPath = "something/{route}",
+			};
+			var requestData = new RequestContext
+			{
 				Parameters = new Dictionary<string, string>
 					{
 						{"route","routevalue"}
 					}
 			};
 
-			var result = _requestCoordinator.ConstructEndpoint(requestData);
+			var result = _requestCoordinator.ConstructEndpoint(endpointContext, requestData);
 
 			Assert.That(result,Is.StringContaining("something/routevalue"));
 		}
@@ -46,9 +49,13 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 		[Test]
 		public void should_substitue_multiple_route_parameters()
 		{
-			var requestData = new RequestData
+			var endpointContext = new EndpointContext
 			{
 				UriPath = "something/{firstRoute}/{secondRoute}/thrid/{thirdRoute}",
+			};
+
+			var requestData = new RequestContext
+			{
 				Parameters = new Dictionary<string, string>
 					{
 						{"firstRoute" , "firstValue"},
@@ -58,7 +65,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 					}
 			};
 
-			var result = _requestCoordinator.ConstructEndpoint(requestData);
+			var result = _requestCoordinator.ConstructEndpoint(endpointContext, requestData);
 
 			Assert.That(result, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
@@ -66,9 +73,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 		[Test]
 		public void routes_should_be_case_insensitive()
 		{
-			var requestData = new RequestData
+			var endpointContext = new EndpointContext
 			{
 				UriPath = "something/{firstRoUte}/{secOndrouTe}/thrid/{tHirdRoute}",
+			};
+			var requestData = new RequestContext
+			{
 				Parameters = new Dictionary<string, string>
 					{
 						{"firstRoute" , "firstValue"},
@@ -78,7 +88,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 					}
 			};
 
-			var result = _requestCoordinator.ConstructEndpoint(requestData);
+			var result = _requestCoordinator.ConstructEndpoint(endpointContext, requestData);
 
 			Assert.That(result, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
@@ -86,16 +96,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 		[Test]
 		public void should_handle_dashes_and_numbers()
 		{
-			var requestData = new RequestData
+			var endpointContext = new EndpointContext
 			{
 				UriPath = "something/{route-66}",
+			};
+			var requestData = new RequestContext
+			{
 				Parameters = new Dictionary<string, string>
 					{
 						{"route-66","routevalue"}
 					}
 			};
 
-			var result = _requestCoordinator.ConstructEndpoint(requestData);
+			var result = _requestCoordinator.ConstructEndpoint(endpointContext, requestData);
 
 			Assert.That(result, Is.StringContaining("something/routevalue"));
 		}
@@ -103,16 +116,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution
 		[Test]
 		public void should_remove_parameters_that_match()
 		{
-			var requestData = new RequestData
+			var endpointContext = new EndpointContext
 			{
 				UriPath = "something/{route-66}",
+			};
+			var requestData = new RequestContext
+			{
 				Parameters = new Dictionary<string, string>
 					{
 						{"route-66","routevalue"}
 					}
 			};
 
-			var result = _requestCoordinator.ConstructEndpoint(requestData);
+			var result = _requestCoordinator.ConstructEndpoint(endpointContext, requestData);
 
 			Assert.That(result, Is.Not.StringContaining("route-66=routevalue"));
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -22,12 +22,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		public void Should_fire_requestcoordinator_with_correct_endpoint_on_resolve()
 		{
 			var requestCoordinator = A.Fake<IRequestCoordinator>();
-			A.CallTo(() => requestCoordinator.HitEndpoint(A<RequestData>.Ignored)).Returns(stubResponse);
+			A.CallTo(() => requestCoordinator.HitEndpoint(A<EndpointContext>.Ignored, A<RequestContext>.Ignored)).Returns(stubResponse);
 
 			new FluentApi<Status>(requestCoordinator).Please();
 
 			Expression<Func<Response>> callWithEndpointStatus =
-				() => requestCoordinator.HitEndpoint(A<RequestData>.That.Matches(x => x.UriPath == "status"));
+				() => requestCoordinator.HitEndpoint(A<EndpointContext>.That.Matches(x => x.UriPath == "status"), A<RequestContext>.Ignored);
 
 			A.CallTo(callWithEndpointStatus).MustHaveHappened(Repeated.Exactly.Once);
 		}
@@ -36,12 +36,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		public void Should_fire_requestcoordinator_with_correct_methodname_on_resolve()
 		{
 			var requestCoordinator = A.Fake<IRequestCoordinator>();
-			A.CallTo(() => requestCoordinator.HitEndpoint(A<RequestData>.Ignored)).Returns(stubResponse);
+			A.CallTo(() => requestCoordinator.HitEndpoint(A<EndpointContext>.Ignored, A<RequestContext>.Ignored)).Returns(stubResponse);
 
 			new FluentApi<Status>(requestCoordinator).WithMethod("POST").Please();
 
 			Expression<Func<Response>> callWithMethodPost =
-				() => requestCoordinator.HitEndpoint(A<RequestData>.That.Matches(x => x.HttpMethod == "POST"));
+				() => requestCoordinator.HitEndpoint(A<EndpointContext>.That.Matches(x => x.HttpMethod == "POST"), A<RequestContext>.Ignored);
 
 			A.CallTo(callWithMethodPost).MustHaveHappened(Repeated.Exactly.Once);
 		}
@@ -50,12 +50,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		public void Should_fire_requestcoordinator_with_correct_parameters_on_resolve()
 		{
 			var requestCoordinator = A.Fake<IRequestCoordinator>();
-			A.CallTo(() => requestCoordinator.HitEndpoint(A<RequestData>.Ignored)).Returns(stubResponse);
+			A.CallTo(() => requestCoordinator.HitEndpoint(A<EndpointContext>.Ignored, A<RequestContext>.Ignored)).Returns(stubResponse);
 
 			new FluentApi<Status>(requestCoordinator).WithParameter("artistId", "123").Please();
 
 			Expression<Func<Response>> callWithArtistId123 =
-				() => requestCoordinator.HitEndpoint(A<RequestData>.That.Matches(x => x.Parameters["artistId"] == "123"));
+				() => requestCoordinator.HitEndpoint(A<EndpointContext>.Ignored, A<RequestContext>.That.Matches(x => x.Parameters["artistId"] == "123"));
 
 			A.CallTo(callWithArtistId123).MustHaveHappened();
 
@@ -93,22 +93,22 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 
 		public class FakeRequestCoordinator : IRequestCoordinator
 		{
-			public Response HitEndpoint(RequestData requestData)
+			public Response HitEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 			{
 				throw new NotImplementedException();
 			}
 
-			public Response HitEndpointAndGetResponse(RequestData requestData)
+			public Response HitEndpointAndGetResponse(RequestContext requestContext)
 			{
 				throw new NotImplementedException();
 			}
 
-			public void HitEndpointAsync(RequestData requestData, Action<Response> callback)
+			public void HitEndpointAsync(EndpointContext endpointContext, RequestContext requestContext, Action<Response> callback)
 			{
 				callback(StubPayload);
 			}
 
-			public string ConstructEndpoint(RequestData requestData)
+			public string ConstructEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 			{
 				throw new NotImplementedException();
 			}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Http/RequestCoordinatorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Http/RequestCoordinatorTests.cs
@@ -39,9 +39,10 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 			var expectedHeaders = new Dictionary<string, string>();
 			var expected = string.Format("{0}/test?oauth_consumer_key={1}", API_URL, _consumerKey);
 
-			var requestData = new RequestData { UriPath = "test", HttpMethod = expectedMethod, Headers = expectedHeaders };
+			var requestData = new RequestContext { Headers = expectedHeaders };
+			var endpointContext = new EndpointContext() { UriPath = "test", HttpMethod = expectedMethod };
 
-			_requestCoordinator.HitEndpoint(requestData);
+			_requestCoordinator.HitEndpoint(endpointContext, requestData);
 
 			A.CallTo(() => _httpClient
 					.Get(A<GetRequest>.That.Matches(y => y.Url == expected)))
@@ -61,9 +62,10 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 			var testParameters = new Dictionary<string, string> { { "q", unEncodedParameterValue } };
 			var expected = string.Format("{0}/test?oauth_consumer_key={1}&q={2}", API_URL, _consumerKey, expectedParameterValue);
 
-			var requestData = new RequestData { UriPath = "test", HttpMethod = "GET", Headers = expectedHeaders, Parameters = testParameters };
+			var requestData = new RequestContext { Headers = expectedHeaders, Parameters = testParameters };
+			var endpointContext = new EndpointContext() { UriPath = "test", HttpMethod = "GET", };
 
-			_requestCoordinator.HitEndpoint(requestData);
+			_requestCoordinator.HitEndpoint(endpointContext, requestData);
 
 			A.CallTo(() => _httpClient
 					.Get(A<GetRequest>.That.Matches(y => y.Url == expected)))
@@ -73,15 +75,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 		[Test]
 		public void Should_not_care_how_many_times_you_create_an_endpoint()
 		{
-			var endPointState = new RequestData
+			var requestContext = new RequestContext
 				{
-					UriPath = "{slug}", 
-					HttpMethod = "GET", 
 					Parameters = new Dictionary<string, string> { { "slug", "something" } }
 				};
-			var result = _requestCoordinator.ConstructEndpoint(endPointState);
 
-			Assert.That(result, Is.EqualTo(_requestCoordinator.ConstructEndpoint(endPointState)));
+			var endpointContext = new EndpointContext
+			{
+				UriPath = "{slug}",
+				HttpMethod = "GET",
+			};
+			var result = _requestCoordinator.ConstructEndpoint(endpointContext, requestContext);
+
+			Assert.That(result, Is.EqualTo(_requestCoordinator.ConstructEndpoint(endpointContext, requestContext)));
 		}
 
 		[Test]
@@ -89,7 +95,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 		{
 			Given_a_urlresolver_that_returns_valid_xml();
 
-			var response = _requestCoordinator.HitEndpoint(new RequestData());
+			var response = _requestCoordinator.HitEndpoint(new EndpointContext(), new RequestContext());
 			var hitEndpoint = new XmlDocument();
 			hitEndpoint.LoadXml(response.Body);
 			Assert.That(hitEndpoint.HasChildNodes);
@@ -107,7 +113,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 			var reset = new AutoResetEvent(false);
 
 			string response = string.Empty;
-			endpointResolver.HitEndpointAsync(new RequestData(),
+			endpointResolver.HitEndpointAsync(new EndpointContext(), new RequestContext(),
 			 s =>
 				{
 					response = s.Body;
@@ -136,14 +142,17 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 			IOAuthCredentials oAuthCredentials = EssentialDependencyCheck<IOAuthCredentials>.Instance;
 			var endpointResolver = new RequestCoordinator(_httpClient, _urlSigner, oAuthCredentials, apiUri);
 
-			var requestData = new RequestData
+			var endpointContext = new EndpointContext
 				{
 					UriPath = "test", 
 					HttpMethod = "GET", 
-					Headers = new Dictionary<string, string>()
 				};
+			var requestData = new RequestContext
+			{
+				Headers = new Dictionary<string, string>()
+			};
 
-			endpointResolver.HitEndpoint(requestData);
+			endpointResolver.HitEndpoint(endpointContext, requestData);
 
 			A.CallTo(() => apiUri.Uri).MustHaveHappened(Repeated.Exactly.Once);
 
@@ -156,7 +165,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 		public void Construct_url_should_combine_url_and_query_params_for_get_requests()
 		{
 			const string uriPath = "something";
-			var result = _requestCoordinator.ConstructEndpoint(new RequestData { UriPath = uriPath });
+			var result = _requestCoordinator.ConstructEndpoint(new EndpointContext() { UriPath = uriPath }, new RequestContext());
 
 			Assert.That(result, Is.EqualTo(API_URL + "/" + uriPath + "?oauth_consumer_key=" + _consumerKey));
 		}
@@ -165,7 +174,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 		public void Construct_url_should_combine_url_and_not_query_params_for_post_requests()
 		{
 			const string uriPath = "something";
-			var result = _requestCoordinator.ConstructEndpoint(new RequestData { UriPath = uriPath,HttpMethod = "POST" });
+			var result = _requestCoordinator.ConstructEndpoint(new EndpointContext()  { UriPath = uriPath,HttpMethod = "POST" }, new RequestContext());
 
 			Assert.That(result, Is.EqualTo(API_URL + "/" + uriPath ));
 		}

--- a/src/SevenDigital.Api.Wrapper/AttributeManagement/AttributeEndpointContextBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/AttributeManagement/AttributeEndpointContextBuilder.cs
@@ -6,22 +6,22 @@ using SevenDigital.Api.Wrapper.Http;
 
 namespace SevenDigital.Api.Wrapper.AttributeManagement
 {
-	public class AttributeRequestDataBuilder<T>
+	public class AttributeEndpointContextBuilder<T>
 	{
-		public RequestData BuildRequestData()
+		public EndpointContext BuildRequestData()
 		{
-			var requestData = new RequestData();
+			var endpointContext = new EndpointContext();
 
-			requestData.UriPath = ParseApiEndpointAttribute();
-			requestData.IsSigned = ParseOAuthSignedAttribute();
-			requestData.UseHttps = ParseRequireSecureAttribute();
+			endpointContext.UriPath = ParseApiEndpointAttribute();
+			endpointContext.IsSigned = ParseOAuthSignedAttribute();
+			endpointContext.UseHttps = ParseRequireSecureAttribute();
 
 			if (ParseHttpPostAttribute() != null)
 			{
-				requestData.HttpMethod = "POST";
+				endpointContext.HttpMethod = "POST";
 			}
 
-			return requestData;
+			return endpointContext;
 		}
 
 		private static string ParseApiEndpointAttribute()

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/IRequestCoordinator.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/IRequestCoordinator.cs
@@ -5,10 +5,10 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution
 {
 	public interface IRequestCoordinator
 	{
-		Response HitEndpoint(RequestData requestData);
-		void HitEndpointAsync(RequestData requestData, Action<Response> callback);
+		Response HitEndpoint(EndpointContext endpointContext, RequestContext requestContext);
+		void HitEndpointAsync(EndpointContext endpointContext, RequestContext requestContext, Action<Response> callback);
 
-		string ConstructEndpoint(RequestData requestData);
+		string ConstructEndpoint(EndpointContext endpointContext, RequestContext requestContext);
 		IHttpClient HttpClient { get; set; }
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestCoordinator.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestCoordinator.cs
@@ -21,14 +21,14 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution
 			_apiUri = apiUri;
 		}
 
-		public string ConstructEndpoint(RequestData requestData)
+		public string ConstructEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			return ConstructBuilder(requestData).ConstructEndpoint(requestData);
+			return ConstructBuilder(endpointContext).ConstructEndpoint(endpointContext, requestContext);
 		}
 
-		private RequestHandler ConstructBuilder(RequestData requestData)
+		private RequestHandler ConstructBuilder(EndpointContext endpointContext)
 		{
-			switch (requestData.HttpMethod.ToUpperInvariant())
+			switch (endpointContext.HttpMethod.ToUpperInvariant())
 			{
 				case "GET":
 					return new GetRequestHandler(_apiUri, _oAuthCredentials, _urlSigner);
@@ -39,18 +39,18 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution
 			}
 		}
 
-		public virtual Response HitEndpoint(RequestData requestData)
+		public virtual Response HitEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			var builder = ConstructBuilder(requestData);
+			var builder = ConstructBuilder(endpointContext);
 			builder.HttpClient = HttpClient;
-			return builder.HitEndpoint(requestData);
+			return builder.HitEndpoint(endpointContext, requestContext);
 		}
 
-		public virtual void HitEndpointAsync(RequestData requestData, Action<Response> callback)
+		public virtual void HitEndpointAsync(EndpointContext endpointContext, RequestContext requestContext, Action<Response> callback)
 		{
-			var builder = ConstructBuilder(requestData);
+			var builder = ConstructBuilder(endpointContext);
 			builder.HttpClient = HttpClient;
-			builder.HitEndpointAsync(requestData, callback);
+			builder.HitEndpointAsync(endpointContext, requestContext, callback);
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/GetRequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/GetRequestHandler.cs
@@ -16,31 +16,31 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 			_urlSigner = urlSigner;
 		}
 
-		public override Response HitEndpoint(RequestData requestData)
+		public override Response HitEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			var getRequest = BuildGetRequest(requestData);
+			var getRequest = BuildGetRequest(endpointContext, requestContext);
 			return HttpClient.Get(getRequest);
 		}
 
-		private GetRequest BuildGetRequest(RequestData requestData)
+		private GetRequest BuildGetRequest(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			var uri = ConstructEndpoint(requestData);
-			var signedUrl = SignHttpGetUrl(uri, requestData);
-			var getRequest = new GetRequest(signedUrl, requestData.Headers);
+			var uri = ConstructEndpoint(endpointContext, requestContext);
+			var signedUrl = SignHttpGetUrl(uri, endpointContext);
+			var getRequest = new GetRequest(signedUrl, requestContext.Headers);
 			return getRequest;
 		}
 
-		public override void HitEndpointAsync(RequestData requestData, Action<Response> action)
+		public override void HitEndpointAsync(EndpointContext endpointContext, RequestContext requestContext, Action<Response> action)
 		{
-			var getRequest = BuildGetRequest(requestData);
+			var getRequest = BuildGetRequest(endpointContext, requestContext);
 			HttpClient.GetAsync(getRequest, response => action(response));
 		}
 
-		private string SignHttpGetUrl(string uri, RequestData requestData)
+		private string SignHttpGetUrl(string uri, EndpointContext endpointContext)
 		{
-			if (requestData.IsSigned)
+			if (endpointContext.IsSigned)
 			{
-				return _urlSigner.SignGetUrl(uri, requestData.UserToken, requestData.TokenSecret, _oAuthCredentials);
+				return _urlSigner.SignGetUrl(uri, endpointContext.UserToken, endpointContext.TokenSecret, _oAuthCredentials);
 			}
 			return uri;
 		}

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/PostRequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/PostRequestHandler.cs
@@ -16,32 +16,32 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 			_urlSigner = urlSigner;
 		}
 
-		public override Response HitEndpoint(RequestData requestData)
+		public override Response HitEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			var postRequest = BuildPostRequest(requestData);
+			var postRequest = BuildPostRequest(endpointContext, requestContext);
 			return HttpClient.Post(postRequest);
 		}
-		public override void HitEndpointAsync(RequestData requestData, Action<Response> action)
+		public override void HitEndpointAsync(EndpointContext endpointContext, RequestContext requestContext, Action<Response> action)
 		{
-			var postRequest = BuildPostRequest(requestData);
+			var postRequest = BuildPostRequest(endpointContext, requestContext);
 			HttpClient.PostAsync(postRequest,response => action(response));
 		}
 
-		private PostRequest BuildPostRequest(RequestData requestData)
+		private PostRequest BuildPostRequest(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			var uri = ConstructEndpoint(requestData);
-			var signedParams = SignHttpPostParams(uri, requestData);
-			var postRequest = new PostRequest(uri, requestData.Headers, signedParams);
+			var uri = ConstructEndpoint(endpointContext, requestContext);
+			var signedParams = SignHttpPostParams(uri, endpointContext, requestContext);
+			var postRequest = new PostRequest(uri, requestContext.Headers, signedParams);
 			return postRequest;
 		}
 
-		private IDictionary<string, string> SignHttpPostParams(string uri, RequestData requestData)
+		private IDictionary<string, string> SignHttpPostParams(string uri, EndpointContext endpointContext, RequestContext requestContext)
 		{
-			if (requestData.IsSigned)
+			if (endpointContext.IsSigned)
 			{
-				return _urlSigner.SignPostRequest(uri, requestData.UserToken, requestData.TokenSecret, _oAuthCredentials, requestData.Parameters);
+				return _urlSigner.SignPostRequest(uri, endpointContext.UserToken, endpointContext.TokenSecret, _oAuthCredentials, requestContext.Parameters);
 			}
-			return requestData.Parameters;
+			return requestContext.Parameters;
 		}
 
 		protected override string AdditionalParameters(Dictionary<string, string> newDictionary)

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RequestHandler.cs
@@ -8,8 +8,8 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 {
 	public abstract class RequestHandler
 	{
-		public abstract Response HitEndpoint(RequestData requestData);
-		public abstract void HitEndpointAsync(RequestData requestData, Action<Response> action);
+		public abstract Response HitEndpoint(EndpointContext endpointContext, RequestContext requestContext);
+		public abstract void HitEndpointAsync(EndpointContext endpointContext, RequestContext requestContext, Action<Response> action);
 		protected abstract string AdditionalParameters(Dictionary<string, string> newDictionary);
 
 		private readonly IApiUri _apiUri;
@@ -21,13 +21,13 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 
 		public IHttpClient HttpClient { get; set; }
 
-		public virtual string ConstructEndpoint(RequestData requestData)
+		public virtual string ConstructEndpoint(EndpointContext endpointContext, RequestContext requestContext)
 		{
-			var apiUri = requestData.UseHttps ? _apiUri.SecureUri : _apiUri.Uri;
+			var apiUri = endpointContext.UseHttps ? _apiUri.SecureUri : _apiUri.Uri;
 
-			var newDictionary = requestData.Parameters.ToDictionary(entry => entry.Key, entry => entry.Value);
+			var newDictionary = requestContext.Parameters.ToDictionary(entry => entry.Key, entry => entry.Value);
 
-			var uriString = string.Format("{0}/{1}", apiUri, SubstituteRouteParameters(requestData.UriPath, newDictionary));
+			var uriString = string.Format("{0}/{1}", apiUri, SubstituteRouteParameters(endpointContext.UriPath, newDictionary));
 
 			uriString = uriString + AdditionalParameters(newDictionary);
 			return uriString;

--- a/src/SevenDigital.Api.Wrapper/Http/EndpointContext.cs
+++ b/src/SevenDigital.Api.Wrapper/Http/EndpointContext.cs
@@ -1,36 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 
 namespace SevenDigital.Api.Wrapper.Http
 {
-	public class RequestData
+	public class EndpointContext
 	{
 		public string UriPath { get; set; }
-
 		public string HttpMethod { get; set; }
-
-		public IDictionary<string,string> Parameters { get; set; }
-
-		public IDictionary<string,string> Headers { get; set; }
-
 		public bool UseHttps { get; set; }
-
 		public string UserToken { get; set; }
-
 		public string TokenSecret { get; set; }
-
 		[Obsolete("Use TokenSecret")]
 		public string UserSecret { get { return TokenSecret; } set { TokenSecret = value; } }
-
 		public bool IsSigned { get; set; }
 
-		public RequestData()
+		public EndpointContext()
 		{
 			UriPath = string.Empty;
 			HttpMethod = "GET";
-			Parameters = new Dictionary<string,string>();
-			Headers = new Dictionary<string,string>();
-			UseHttps = false;
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Http/RequestContext.cs
+++ b/src/SevenDigital.Api.Wrapper/Http/RequestContext.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace SevenDigital.Api.Wrapper.Http
+{
+	public class RequestContext
+	{
+		public IDictionary<string,string> Parameters { get; set; }
+
+		public IDictionary<string,string> Headers { get; set; }
+
+		public RequestContext()
+		{
+			Parameters = new Dictionary<string,string>();
+			Headers = new Dictionary<string,string>();
+		}
+	}
+}

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Api.cs" />
-    <Compile Include="AttributeManagement\AttributeRequestDataBuilder.cs" />
+    <Compile Include="AttributeManagement\AttributeEndpointContextBuilder.cs" />
     <Compile Include="EndpointResolution\AppDomainAssemblyResolver.cs" />
     <Compile Include="EndpointResolution\EssentialDependencyCheck.cs" />
     <Compile Include="EndpointResolution\RequestHandlers\GetRequestHandler.cs" />
@@ -81,13 +81,14 @@
     <Compile Include="Extensions\HasUserDeliverItemParameterExtensions.cs" />
     <Compile Include="Extensions\LockerSortColumn.cs" />
     <Compile Include="Extensions\SortOrder.cs" />
+    <Compile Include="Http\EndpointContext.cs" />
     <Compile Include="IApiEndpoint.cs" />
     <Compile Include="IApiUri.cs" />
     <Compile Include="IOAuthCredentials.cs" />
     <Compile Include="EndpointResolution\OAuth\IUrlSigner.cs" />
     <Compile Include="EndpointResolution\OAuth\OAuthBase.cs" />
     <Compile Include="EndpointResolution\OAuth\UrlSigner.cs" />
-    <Compile Include="Http\RequestData.cs" />
+    <Compile Include="Http\RequestContext.cs" />
     <Compile Include="FluentApi.cs" />
     <Compile Include="IFluentApi.cs" />
     <Compile Include="EndpointResolution\DictionaryExtensions.cs" />


### PR DESCRIPTION
- EndpointContext stores endpoint specific attributes that do not vary
  between requests.
- RequestContext stores request specific attributes.
- Rename AttributeRequestDataBuilder as it now only builds up
  the EndpointContext
- Pass the EndpointContext and RRequestContext down the layers to the
  RequestHandlers.

This pull request lays some of the groundwork for my proposed solution for resolving concurrency problems in #20.
