### PR TITLE
Rename HttpClient to HttpClientWrapper

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/Http/HttpClientWrapperTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/Http/HttpClientWrapperTests.cs
@@ -8,7 +8,7 @@ using SevenDigital.Api.Wrapper.Http;
 namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 {
 	[TestFixture]
-	public class HttpClientTests
+	public class HttpClientWrapperTests
 	{
 		private const string ApiUrl = "http://api.7digital.com/1.2";
 		private readonly TimeSpan AsyncTimeout = new TimeSpan(0, 0, 0, 20);
@@ -26,7 +26,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			string url = string.Format("{0}/status?oauth_consumer_key={1}", ApiUrl, consumerKey);
 			var request = new GetRequest(url,  new Dictionary<string, string>());
 
-			var response = new HttpClient().Get(request);
+			var response = new HttpClientWrapper().Get(request);
 			AssertResponse(response, HttpStatusCode.OK);
 		}
 
@@ -45,7 +45,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 				autoResetEvent.Set();
 			};
 
-			new HttpClient().GetAsync(request, callback);
+			new HttpClientWrapper().GetAsync(request, callback);
 
 			var signalled = autoResetEvent.WaitOne(AsyncTimeout);
 			Assert.That(signalled, Is.True, "event was not signalled");
@@ -59,7 +59,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			string url = string.Format("{0}/foo/bar/fish/1234?oauth_consumer_key={1}", ApiUrl, consumerKey);
 			var request = new GetRequest(url, new Dictionary<string, string>());
 
-			var response = new HttpClient().Get(request);
+			var response = new HttpClientWrapper().Get(request);
 			AssertResponse(response, HttpStatusCode.NotFound);
 		}
 
@@ -78,7 +78,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 				autoResetEvent.Set();
 			};
 
-			new HttpClient().GetAsync(request, callback);
+			new HttpClientWrapper().GetAsync(request, callback);
 
 			var signalled = autoResetEvent.WaitOne(AsyncTimeout);
 			Assert.That(signalled, Is.True, "event was not signalled");
@@ -92,7 +92,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			string url = string.Format("{0}/status", ApiUrl);
 			var request = new GetRequest(url, new Dictionary<string, string>());
 
-			var response = new HttpClient().Get(request);
+			var response = new HttpClientWrapper().Get(request);
 			AssertResponse(response, HttpStatusCode.Unauthorized);
 		}
 
@@ -105,7 +105,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			var apiUrl = "http://hanging-web-app.7digital.local";
 			var request = new GetRequest(apiUrl, new Dictionary<string, string>());
 
-			var response = new HttpClient().Get(request);
+			var response = new HttpClientWrapper().Get(request);
 			AssertResponse(response, HttpStatusCode.OK);
 		}
 
@@ -121,7 +121,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 
 			var request = new PostRequest(url, new Dictionary<string, string>(), parameters);
 
-			var response = new HttpClient().Post(request);
+			var response = new HttpClientWrapper().Post(request);
 			AssertResponse(response, HttpStatusCode.NotFound);
 		}
 
@@ -145,7 +145,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 				autoResetEvent.Set();
 			};
 
-			new HttpClient().PostAsync(request, callback);
+			new HttpClientWrapper().PostAsync(request, callback);
 
 			var signalled = autoResetEvent.WaitOne(AsyncTimeout);
 			Assert.That(signalled, Is.True, "event was not signalled");

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
@@ -84,7 +84,7 @@
     <Compile Include="Exceptions\ErrorConditionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Http\GzipHttpClientTests.cs" />
-    <Compile Include="Http\HttpClientTests.cs" />
+    <Compile Include="Http\HttpClientWrapperTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SevenDigital.Api.Schema\SevenDigital.Api.Schema.csproj">

--- a/src/SevenDigital.Api.Wrapper/Http/HttpClientWrapper.cs
+++ b/src/SevenDigital.Api.Wrapper/Http/HttpClientWrapper.cs
@@ -7,7 +7,7 @@ using SevenDigital.Api.Wrapper.EndpointResolution;
 
 namespace SevenDigital.Api.Wrapper.Http
 {
-	public class HttpClient : IHttpClient
+	public class HttpClientWrapper : IHttpClient
 	{
 		public Response Get(GetRequest request)
 		{

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -99,7 +99,7 @@
     <Compile Include="Http\GzipHttpClient.cs" />
     <Compile Include="Http\PostRequest.cs" />
     <Compile Include="Http\GetRequest.cs" />
-    <Compile Include="Http\HttpClient.cs" />
+    <Compile Include="Http\HttpClientWrapper.cs" />
     <Compile Include="Http\IHttpClient.cs" />
     <Compile Include="Http\Response.cs" />
     <Compile Include="Serialization\ApiResponseDetector.cs" />


### PR DESCRIPTION
The name "HttpClient" causes complexities
as it clashes with the class System.Net.Http.HttpClient (new in .Net 4.5)
Which this class will eventually be a wrapper of.
