### PR TITLE
Fix failing customer support integration test

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/CustomerSupportEndpoint/CustomerSupportEndpointTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/CustomerSupportEndpoint/CustomerSupportEndpointTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
+using NUnit.Framework;
 using SevenDigital.Api.Schema.CustomerSupport;
 
 namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.CustomerSupportEndpoint
@@ -7,19 +8,29 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.CustomerSuppo
 	public class CustomerSupportEndpointTests
 	{
 		[Test]
-		public void Should_get_an_empty_response()
+		public void Should_generate_endpoint_url()
 		{
-			var reponse = Api<CustomerSupport>
-				.Create
-				.WithParameter("Email", "web-devteam-testing@7digital.com")
+			var api = new FluentApi<CustomerSupport>();
+			Assert.That(api.EndpointUrl, Is.EqualTo("https://api.7digital.com/1.2/customersupport"));
+		}
+
+		[Test]
+		public void Should_generate_parameters()
+		{
+			var api = new FluentApi<CustomerSupport>();
+			api.WithParameter("Email", "web-devteam-testing@7digital.com")
 				.WithParameter("Message", "Integration test")
 				.WithParameter("ClientName", "Web Team")
 				.WithParameter("AdditionalClientInfo", "")
 				.WithParameter("PartnerId", "0")
-				.WithParameter("ShopId", "34")
-				.Please();
+				.WithParameter("ShopId", "34");
 
-			Assert.That(reponse, Is.Not.Null);
+			Assert.That(api.Parameters, Contains.Item(new KeyValuePair<string, string>("Email", "web-devteam-testing@7digital.com")));
+			Assert.That(api.Parameters, Contains.Item(new KeyValuePair<string, string>("ClientName", "Web Team")));
+			Assert.That(api.Parameters, Contains.Item(new KeyValuePair<string, string>("Message", "Integration test")));
+			Assert.That(api.Parameters, Contains.Item(new KeyValuePair<string, string>("AdditionalClientInfo", "")));
+			Assert.That(api.Parameters, Contains.Item(new KeyValuePair<string, string>("PartnerId", "0")));
+			Assert.That(api.Parameters, Contains.Item(new KeyValuePair<string, string>("ShopId", "34")));
 		}
 	}
 }


### PR DESCRIPTION
- This test was failing because it required access to a private endpoint
- Replaced the test so that it no longer hits the endpoint - I've put in
  two tests to check the endpoint generated and the parameters generated
