### PR TITLE
Simpler message on NonXmlResponseException

### DIFF
--- a/src/SevenDigital.Api.Wrapper/Exceptions/NonXmlResponseException.cs
+++ b/src/SevenDigital.Api.Wrapper/Exceptions/NonXmlResponseException.cs
@@ -7,7 +7,7 @@ namespace SevenDigital.Api.Wrapper.Exceptions
 	[Serializable]
 	public class NonXmlResponseException : ApiResponseException
 	{
-		public const string DEFAULT_ERROR_MESSAGE = "Error deserializing xml response";
+		public const string DEFAULT_ERROR_MESSAGE = "Response is not xml";
 
 		public NonXmlResponseException(Response response)
 			: base(DEFAULT_ERROR_MESSAGE, response)


### PR DESCRIPTION
"Error deserializing xml" implies that we used a deserialiser which is not so.
This has caused some confusion
