### PR TITLE
Support for adding custom headers to an API request

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -62,6 +62,20 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		}
 
 		[Test]
+		public void Should_fire_requestcoordinator_with_correct_headers_on_resolve()
+		{
+			var requestCoordinator = A.Fake<IRequestCoordinator>();
+			A.CallTo(() => requestCoordinator.HitEndpoint(A<RequestData>.Ignored)).Returns(stubResponse);
+
+			new FluentApi<Status>(requestCoordinator).WithHeader("customHeader", "myHeaderValue").Please();
+
+			Expression<Func<Response>> hitEndpointWithCustomHeader =
+				() => requestCoordinator.HitEndpoint(A<RequestData>.That.Matches(x => x.Headers["customHeader"] == "myHeaderValue"));
+
+			A.CallTo(hitEndpointWithCustomHeader).MustHaveHappened();
+		}
+
+		[Test]
 		public void Should_use_custom_http_client()
 		{
 			var fakeRequestCoordinator = A.Fake<IRequestCoordinator>();

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -59,6 +59,12 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		}
 
+		public virtual IFluentApi<T> WithHeader(string headerName, string headerValue)
+		{
+			_requestData.Headers[headerName] = headerValue;
+			return this;
+		}
+
 		public virtual IFluentApi<T> ClearParameters()
 		{
 			_requestData.Parameters.Clear();


### PR DESCRIPTION
We would like to submit some diagnostic data to certain API endpoints in the form of headers.  The wrapper already has a headers dictionary that it passes with all requests, but there isn't a way to actually add to it.  I've added a WithHeader method to the FluentApi that works in the same way as WithParameter.
