### PR TITLE
Be defensive - FluentApi should not accept null httpclient or cache

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -74,6 +74,15 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		}
 
 		[Test]
+		public void Should_throw_exception_when_null_client_is_used()
+		{
+			var fakeRequestCoordinator = A.Fake<IRequestCoordinator>();
+			var api = new FluentApi<Status>(fakeRequestCoordinator);
+
+			Assert.Throws<ArgumentNullException>(() => api.UsingClient(null));
+		}
+
+		[Test]
 		public void should_put_payload_in_action_result()
 		{
 			var requestCoordinator = new FakeRequestCoordinator { StubPayload = stubResponse };
@@ -105,6 +114,15 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 			Assert.That(ex.InnerException, Is.Not.Null);
 			Assert.That(ex.Uri, Is.EqualTo(url));
 			Assert.That(ex.InnerException.GetType(), Is.EqualTo(typeof(WebException)));
+		}
+
+		[Test]
+		public void Should_throw_exception_when_null_cache_is_used()
+		{
+			var fakeRequestCoordinator = A.Fake<IRequestCoordinator>();
+			var api = new FluentApi<Status>(fakeRequestCoordinator);
+
+			Assert.Throws<ArgumentNullException>(() => api.UsingCache(null));
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -37,12 +37,22 @@ namespace SevenDigital.Api.Wrapper
 
 		public IFluentApi<T> UsingClient(IHttpClient httpClient)
 		{
+			if (httpClient == null)
+			{
+				throw new ArgumentNullException("httpClient");
+			}
+
 			_requestCoordinator.HttpClient = httpClient;
 			return this;
 		}
 
 		public IFluentApi<T> UsingCache(IResponseCache responseCache)
 		{
+			if (responseCache == null)
+			{
+				throw new ArgumentNullException("responseCache");
+			}
+
 			_responseCache = responseCache;
 			return this;
 		}


### PR DESCRIPTION
 FluentApi should not accept null httpclient or cache, as these will just cause exceptions to be thrown later.
This provides a better error message.
This is a minor thing but would be useful in our tests today.
