### PR TITLE
Ignore failing track preview test

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/TrackEndpoint/TrackPreviewTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/TrackEndpoint/TrackPreviewTests.cs
@@ -6,7 +6,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.TrackEndpoint
 	[TestFixture]
 	public class TrackPreviewTests
 	{
-		[Test]
+		[Test, Ignore("Waiting for API fix to reinstate XML declaration")]
 		public void Can_hit_endpoint_with_redirect_false()
 		{
 			TrackPreview track = Api<TrackPreview>.Create


### PR DESCRIPTION
- This is failing due to a missing XML declaration.  The API is being fixed
  to reinstate it.  

This is as discussed in #93
