### PR TITLE
Add TrackCount property to release schema

### DIFF
--- a/src/SevenDigital.Api.Schema/ReleaseEndpoint/Release.cs
+++ b/src/SevenDigital.Api.Schema/ReleaseEndpoint/Release.cs
@@ -63,5 +63,8 @@ namespace SevenDigital.Api.Schema.ReleaseEndpoint
 
 		[XmlElement("licensor")]
 		public Licensor Licensor { get; set; }
+
+		[XmlElement("trackCount")]
+		public int? TrackCount { get; set; }
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ReleaseEndpoint/ReleaseDetailsTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ReleaseEndpoint/ReleaseDetailsTests.cs
@@ -18,6 +18,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.ReleaseEndpoi
 			Assert.That(release, Is.Not.Null);
 			Assert.That(release.Title, Is.EqualTo("Dreams"));
 			Assert.That(release.Artist.Name, Is.EqualTo("The Whitest Boy Alive"));
+			Assert.That(release.TrackCount, Is.EqualTo(10));
 		}
 
 	}


### PR DESCRIPTION
Add a property that's available in the release details response, but not in the wrapper at the moment.
