### PR TITLE
Refine api response detection not to pick up error statuses on child resources.

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Serialization/ApiResponseDetectorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Serialization/ApiResponseDetectorTests.cs
@@ -9,6 +9,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Serialization
 		private const string DUMMY_HTML = "<html><head><title>Hello world</title></head><body><h1>Hello, test</h1></body></html>";
 		private const string OK_RESPONSE = "<?xml><response status=\"ok\"></response>";
 		private const string ERROR_RESPONSE = "<?xml><response status=\"error\"></response>";
+		private const string OK_RESPONSE_WITH_ERROR_STATUS_IN_CHILD = "<?xml><response status=\"ok\"><child status=\"error\" /></response>";
 		private const string OAUTH_ERROR = "OAuth authentication error: Access to resource denied";
 
 		private IApiResponseDetector _apiResponseDetector;
@@ -55,6 +56,14 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Serialization
 		public void Should_not_detect_error_as_ok_response()
 		{
 			var result = _apiResponseDetector.IsApiOkResponse(ERROR_RESPONSE);
+
+			Assert.That(result, Is.False);
+		}
+
+		[Test]
+		public void Should_not_detect_an_error_status_in_a_child_node()
+		{
+			var result = _apiResponseDetector.IsApiErrorResponse(OK_RESPONSE_WITH_ERROR_STATUS_IN_CHILD);
 
 			Assert.That(result, Is.False);
 		}

--- a/src/SevenDigital.Api.Wrapper/Serialization/ApiResponseDetector.cs
+++ b/src/SevenDigital.Api.Wrapper/Serialization/ApiResponseDetector.cs
@@ -11,8 +11,14 @@ namespace SevenDigital.Api.Wrapper.Serialization
 				return string.Empty;
 			}
 
-			var maxLength = Math.Min(responseBody.Length, 512);
-			return responseBody.Substring(0, maxLength);
+			var start = responseBody.IndexOf("<response", StringComparison.Ordinal);
+			if (start == -1)
+			{
+				return string.Empty;
+			}
+
+			var end = responseBody.IndexOf(">", start, StringComparison.Ordinal);
+			return responseBody.Substring(start, end - start);
 		}
 
 		public bool IsXml(string responseBody)
@@ -23,13 +29,13 @@ namespace SevenDigital.Api.Wrapper.Serialization
 		public bool IsApiOkResponse(string responseBody)
 		{
 			var startOfBody = StartOfMessage(responseBody);
-			return startOfBody.Contains("<response") && startOfBody.Contains("status=\"ok\"");
+			return startOfBody.Contains("status=\"ok\"");
 		}
 
 		public bool IsApiErrorResponse(string responseBody)
 		{
 			var startOfBody = StartOfMessage(responseBody);
-			return startOfBody.Contains("<response") && startOfBody.Contains("status=\"error\"");
+			return startOfBody.Contains("status=\"error\"");
 		}
 
 		public bool IsOAuthError(string responseBody)


### PR DESCRIPTION
A child resource itself may have an attribute of status, this should not result in an error being detected.
