### PR TITLE
Get access token from environment variables or app.config

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/BasketEndpoint/CompletePayPalExpressCheckoutTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/BasketEndpoint/CompletePayPalExpressCheckoutTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 using NUnit.Framework;
 using SevenDigital.Api.Schema.Basket;
 
@@ -11,8 +10,8 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.BasketEndpoin
 		[Test, Ignore("Will always fail. Requires a live user who must interact with PayPal prior to this call")]
 		public void Should_get_paypal_url_for_basket()
 		{
-			var userToken = ConfigurationManager.AppSettings["Integration.Tests.AccessToken"];
-			var userSecret = ConfigurationManager.AppSettings["Integration.Tests.AccessTokenSecret"];
+			var userToken = TestDataFromEnvironmentOrAppSettings.AccessToken;
+			var userSecret = TestDataFromEnvironmentOrAppSettings.AccessTokenSecret;
 
 			Api<CompletePayPalExpressCheckout>
 				.Create

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/LockerEndpoint/LockerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/LockerEndpoint/LockerTests.cs
@@ -1,4 +1,3 @@
-using System.Configuration;
 using System.Linq;
 using NUnit.Framework;
 using SevenDigital.Api.Schema.LockerEndpoint;
@@ -8,13 +7,13 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.LockerEndpoin
 	[TestFixture]
 	public class LockerTests
 	{
-		private readonly string _token = ConfigurationManager.AppSettings["Integration.Tests.AccessToken"];
-		private readonly string _tokenSecret = ConfigurationManager.AppSettings["Integration.Tests.AccessTokenSecret"];
+		private readonly string _token = TestDataFromEnvironmentOrAppSettings.AccessToken;
+		private readonly string _tokenSecret = TestDataFromEnvironmentOrAppSettings.AccessTokenSecret;
 
 		[SetUp]
-		public void RunOnce() 
+		public void RunOnce()
 		{
-			if(string.IsNullOrEmpty(_token) || string.IsNullOrEmpty(_tokenSecret))
+			if (string.IsNullOrEmpty(_token) || string.IsNullOrEmpty(_tokenSecret))
 				Assert.Ignore("these tests need an access token and secret to run");
 		}
 

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Http\GzipHttpClientTests.cs" />
     <Compile Include="Http\HttpClientWrapperTests.cs" />
+    <Compile Include="TestDataFromEnvironmentOrAppSettings.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\SevenDigital.Api.Schema\SevenDigital.Api.Schema.csproj">

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/TestDataFromEnvironmentOrAppSettings.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/TestDataFromEnvironmentOrAppSettings.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Configuration;
+
+namespace SevenDigital.Api.Wrapper.Integration.Tests
+{
+	public class TestDataFromEnvironmentOrAppSettings
+	{
+		public static string AccessToken
+		{
+			get
+			{
+				return Environment.GetEnvironmentVariable("WRAPPER_INTEGRATION_TEST_ACCESS_TOKEN") ??
+					ConfigurationManager.AppSettings["Integration.Tests.AccessToken"];
+			}
+		}
+		public static string AccessTokenSecret
+		{
+			get
+			{
+				return Environment.GetEnvironmentVariable("WRAPPER_INTEGRATION_TEST_ACCESS_TOKEN_SECRET") ??
+					ConfigurationManager.AppSettings["Integration.Tests.AccessTokenSecret"];
+			}
+		}
+	}
+}


### PR DESCRIPTION
This allows the 3 legged access token tests to be run from CI builds
