### PR TITLE
Remove callback async code

### DIFF
--- a/src/SevenDigital.Api.Wrapper.ExampleUsage/Program.cs
+++ b/src/SevenDigital.Api.Wrapper.ExampleUsage/Program.cs
@@ -69,22 +69,13 @@ namespace SevenDigital.Api.Wrapper.ExampleUsage
 			string currentUri = Api<ReleaseSearch>.Create.WithQuery("Test").EndpointUrl;
 			Console.WriteLine("Release search hits: {0}", currentUri);
 
-			// -- async get (async post not implemented yet)
-			Api<ReleaseSearch>.Create
-				.WithQuery(searchValue)
-				.WithPageNumber(1)
-				.WithPageSize(10)
-				.PleaseAsync(x => {
-					Console.WriteLine("Async Release search on \"{0}\" returns: {1} items", "Radio", x.TotalItems);
-					Console.WriteLine();
-				 });
-
 			try 
 			{
 				// -- Deliberate error response
 				Console.WriteLine("Trying artist/details without artistId parameter...");
 				Api<Artist>.Create.Please();
 			} 
+
 			catch (ApiResponseException ex)
 			{
 				Console.WriteLine("{0} : {1}", ex, ex.Message);

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ArtistEndpoint/ArtistDetailsTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ArtistEndpoint/ArtistDetailsTests.cs
@@ -21,30 +21,5 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.ArtistEndpoin
 			Assert.That(artist.Url, Is.StringStarting("http://www.7digital.com/artist/keane/"));
 			Assert.That(artist.Image, Is.EqualTo("http://cdn.7static.com/static/img/artistimages/00/000/000/0000000001_150.jpg"));
 		}
-
-		[Test]
-		public void Can_hit_endpoint_with_fluent_async_api()
-		{
-			Artist artist = null;
-
-			var reset = new AutoResetEvent(false);
-
-			   Api<Artist>
-				.Create
-				.WithArtistId(1)
-				.PleaseAsync(payload =>
-					{
-						artist = payload;
-						reset.Set();
-					});
-
-
-			reset.WaitOne(1000 * 60);
-			Assert.That(artist, Is.Not.Null);
-			Assert.That(artist.Name, Is.EqualTo("Keane"));
-			Assert.That(artist.SortName, Is.EqualTo("Keane"));
-			Assert.That(artist.Url, Is.StringStarting("http://www.7digital.com/artist/keane/"));
-			Assert.That(artist.Image, Is.EqualTo("http://cdn.7static.com/static/img/artistimages/00/000/000/0000000001_150.jpg"));
-		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/Http/HttpClientMediatorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/Http/HttpClientMediatorTests.cs
@@ -1,7 +1,5 @@
-using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Threading;
 using System.Xml;
 using NUnit.Framework;
 using SevenDigital.Api.Wrapper.EndpointResolution;
@@ -13,7 +11,6 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 	public class HttpClientMediatorTests
 	{
 		private const string API_URL = "http://api.7digital.com/1.2";
-		private readonly TimeSpan _asyncTimeout = new TimeSpan(0, 0, 0, 20);
 		private string _consumerKey;
 
 		[SetUp]
@@ -58,58 +55,12 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 		}
 
 		[Test]
-		public void Can_resolve_uri_async()
-		{
-			var url = string.Format("{0}/status?oauth_consumer_key={1}", API_URL, _consumerKey);
-			var request = new GetRequest(url, new Dictionary<string, string>());
-
-			var autoResetEvent = new AutoResetEvent(false);
-			Response response = null;
-
-			Action<Response> callback = callbackResponse =>
-			                            {
-			                            	response = callbackResponse;
-			                            	autoResetEvent.Set();
-			                            };
-
-			new HttpClientMediator().GetAsync(request, callback);
-
-			var signalled = autoResetEvent.WaitOne(_asyncTimeout);
-			Assert.That(signalled, Is.True, "event was not signalled");
-
-			AssertResponse(response, HttpStatusCode.OK);
-		}
-
-		[Test]
 		public void Bad_url_should_return_not_found()
 		{
 			var url = string.Format("{0}/foo/bar/fish/1234?oauth_consumer_key={1}", API_URL, _consumerKey);
 			var request = new GetRequest(url, new Dictionary<string, string>());
 
 			var response = new HttpClientMediator().Get(request);
-			AssertResponse(response, HttpStatusCode.NotFound);
-		}
-
-		[Test]
-		public void Bad_url_should_return_not_found_async()
-		{
-			var url = string.Format("{0}/foo/bar/fish/1234?oauth_consumer_key={1}", API_URL, _consumerKey);
-			var request = new GetRequest(url, new Dictionary<string, string>());
-
-			var autoResetEvent = new AutoResetEvent(false);
-			Response response = null;
-
-			Action<Response> callback = callbackResponse =>
-			                            {
-			                            	response = callbackResponse;
-			                            	autoResetEvent.Set();
-			                            };
-
-			new HttpClientMediator().GetAsync(request, callback);
-
-			var signalled = autoResetEvent.WaitOne(_asyncTimeout);
-			Assert.That(signalled, Is.True, "event was not signalled");
-
 			AssertResponse(response, HttpStatusCode.NotFound);
 		}
 
@@ -149,34 +100,6 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			var request = new PostRequest(url, new Dictionary<string, string>(), parameters.ToQueryString());
 
 			var response = new HttpClientMediator().Post(request);
-			AssertResponse(response, HttpStatusCode.NotFound);
-		}
-
-		[Test]
-		public void bad_url_post_should_return_not_found_async()
-		{
-			string url = string.Format("{0}/foo/bar/fish/1234?oauth_consumer_key={1}", API_URL, _consumerKey);
-			var parameters = new Dictionary<string, string>
-			                 {
-			                 	{"foo", "bar"}
-			                 };
-
-			var request = new PostRequest(url, new Dictionary<string, string>(), parameters.ToQueryString());
-
-			var autoResetEvent = new AutoResetEvent(false);
-			Response response = null;
-
-			Action<Response> callback = callbackResponse =>
-			                            {
-			                            	response = callbackResponse;
-			                            	autoResetEvent.Set();
-			                            };
-
-			new HttpClientMediator().PostAsync(request, callback);
-
-			var signalled = autoResetEvent.WaitOne(_asyncTimeout);
-			Assert.That(signalled, Is.True, "event was not signalled");
-
 			AssertResponse(response, HttpStatusCode.NotFound);
 		}
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -6,7 +6,6 @@ using FakeItEasy;
 using NUnit.Framework;
 using SevenDigital.Api.Wrapper.EndpointResolution;
 using SevenDigital.Api.Schema;
-using System.Threading;
 using SevenDigital.Api.Wrapper.Exceptions;
 using SevenDigital.Api.Wrapper.Http;
 using SevenDigital.Api.Wrapper.Unit.Tests.Http;
@@ -100,24 +99,6 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 			var api = new FluentApi<Status>(fakeRequestCoordinator);
 
 			Assert.Throws<ArgumentNullException>(() => api.UsingClient(null));
-		}
-
-		[Test]
-		public void should_put_payload_in_action_result()
-		{
-			var requestCoordinator = new FakeRequestCoordinator { StubPayload = stubResponse };
-			var reset = new AutoResetEvent(false);
-
-			new FluentApi<Status>(requestCoordinator)
-				.PleaseAsync(
-				status =>
-				{
-					Assert.That(status, Is.Not.Null);
-					reset.Set();
-				});
-
-			var result = reset.WaitOne(1000 * 60);
-			Assert.That(result, Is.True, "Method");
 		}
 
 		[Test]
@@ -224,11 +205,6 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		public Response HitEndpointAndGetResponse(RequestData requestData)
 		{
 			throw new NotImplementedException();
-		}
-
-		public void HitEndpointAsync(RequestData requestData, Action<Response> callback)
-		{
-			callback(StubPayload);
 		}
 
 		public string ConstructEndpoint(RequestData requestData)

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Http/FakeHttpClient.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Http/FakeHttpClient.cs
@@ -21,17 +21,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 			throw new NotImplementedException();
 		}
 
-		public void GetAsync(GetRequest request, Action<Response> callback)
-		{
-			callback(_fakeResponse);
-		}
-
 		public Response Post(PostRequest request)
-		{
-			throw new NotImplementedException();
-		}
-
-		public void PostAsync(PostRequest request, Action<Response> callback)
 		{
 			throw new NotImplementedException();
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Http/RequestCoordinatorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Http/RequestCoordinatorTests.cs
@@ -103,32 +103,6 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Http
 			Assert.That(hitEndpoint.SelectSingleNode("//serverTime"), Is.Not.Null);
 		}
 
-
-		[Test]
-		public void Should_return_xmlnode_if_valid_xml_received_using_async()
-		{
-			var fakeClient = new FakeHttpClient(new Response(HttpStatusCode.OK, SERVICE_STATUS));
-
-			var endpointResolver = new RequestCoordinator(fakeClient, _allRequestHandlers);
-
-			var reset = new AutoResetEvent(false);
-
-			string response = string.Empty;
-			endpointResolver.HitEndpointAsync(new RequestData(),
-			 s =>
-				{
-					response = s.Body;
-					reset.Set();
-				});
-
-			reset.WaitOne(1000 * 5);
-			var payload = new XmlDocument();
-			payload.LoadXml(response);
-
-			Assert.That(payload.HasChildNodes);
-			Assert.That(payload.SelectSingleNode("//serverTime"), Is.Not.Null);
-		}
-
 		[Test]
 		public void Should_use_api_uri_provided_by_IApiUri_interface()
 		{

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/IRequestCoordinator.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/IRequestCoordinator.cs
@@ -6,7 +6,6 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution
 	public interface IRequestCoordinator
 	{
 		Response HitEndpoint(RequestData requestData);
-		void HitEndpointAsync(RequestData requestData, Action<Response> callback);
 
 		string ConstructEndpoint(RequestData requestData);
 		IHttpClient HttpClient { get; set; }

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestCoordinator.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestCoordinator.cs
@@ -43,12 +43,5 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution
 			requestHandler.HttpClient = HttpClient;
 			return requestHandler.HitEndpoint(requestData);
 		}
-
-		public virtual void HitEndpointAsync(RequestData requestData, Action<Response> callback)
-		{
-			var requestHandler = FindRequestHandler(requestData.HttpMethod);
-			requestHandler.HttpClient = HttpClient;
-			requestHandler.HitEndpointAsync(requestData, callback);
-		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/GetRequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/GetRequestHandler.cs
@@ -24,12 +24,6 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 			return HttpClient.Get(getRequest);
 		}
 
-		public override void HitEndpointAsync(RequestData requestData, Action<Response> action)
-		{
-			var getRequest = BuildGetRequest(requestData);
-			HttpClient.GetAsync(getRequest, response => action(response));
-		}
-
 		private GetRequest BuildGetRequest(RequestData requestData)
 		{
 			var apiRequest = MakeApiRequest(requestData);

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/PostRequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/PostRequestHandler.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using SevenDigital.Api.Wrapper.Http;
 using OAuth;
@@ -24,12 +23,6 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 		{
 			var postRequest = BuildPostRequest(requestData);
 			return HttpClient.Post(postRequest);
-		}
-
-		public override void HitEndpointAsync(RequestData requestData, Action<Response> action)
-		{
-			var postRequest = BuildPostRequest(requestData);
-			HttpClient.PostAsync(postRequest,response => action(response));
 		}
 
 		private PostRequest BuildPostRequest(RequestData requestData)

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RequestHandler.cs
@@ -9,7 +9,6 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 	public abstract class RequestHandler
 	{
 		public abstract Response HitEndpoint(RequestData requestData);
-		public abstract void HitEndpointAsync(RequestData requestData, Action<Response> action);
 		public abstract string GetDebugUri(RequestData requestData);
 		public abstract bool HandlesMethod(HttpMethod method);
 

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -128,20 +128,6 @@ namespace SevenDigital.Api.Wrapper
 			get { return _requestCoordinator.ConstructEndpoint(_requestData); }
 		}
 
-		public virtual void PleaseAsync(Action<T> callback)
-		{
-			_requestCoordinator.HitEndpointAsync(_requestData, PleaseAsyncEnd(callback));
-		}
-
-		internal Action<Response> PleaseAsyncEnd(Action<T> callback)
-		{
-			return output =>
-			{
-				T entity = _parser.Parse(output);
-				callback(entity);
-			};
-		}
-
 		public IDictionary<string, string> Parameters
 		{
 			get { return _requestData.Parameters; }

--- a/src/SevenDigital.Api.Wrapper/Http/HttpClientMediator.cs
+++ b/src/SevenDigital.Api.Wrapper/Http/HttpClientMediator.cs
@@ -16,24 +16,11 @@ namespace SevenDigital.Api.Wrapper.Http
 			return TryGetResponse(webRequest.GetResponse);
 		}
 
-		public void GetAsync(GetRequest request, Action<Response> callback)
-		{
-			var webRequest = MakeWebRequest(request.Url, "GET", request.Headers);
-			webRequest.BeginGetResponse(iar => callback(GetAsyncResponse(iar)), webRequest);
-		}
-
 		public Response Post(PostRequest request)
 		{
 			var webRequest = MakePostRequest(request);
 			
 			return TryGetResponse(webRequest.GetResponse);
-		}
-
-		public void PostAsync(PostRequest request, Action<Response> callback)
-		{
-			var webRequest = MakePostRequest(request);
-
-			webRequest.BeginGetResponse(iar => callback(GetAsyncResponse(iar)), webRequest);
 		}
 
 		public Dictionary<string, string> MapHeaders(WebHeaderCollection headerCollection)
@@ -46,13 +33,6 @@ namespace SevenDigital.Api.Wrapper.Http
 			}
 
 			return headers;
-		}
-
-		private Response GetAsyncResponse(IAsyncResult iar)
-		{
-			var webRequest = (WebRequest)iar.AsyncState;
-
-			return TryGetResponse(() => webRequest.EndGetResponse(iar));
 		}
 
 		private Response TryGetResponse(Func<WebResponse> getResponse)

--- a/src/SevenDigital.Api.Wrapper/Http/IHttpClient.cs
+++ b/src/SevenDigital.Api.Wrapper/Http/IHttpClient.cs
@@ -5,9 +5,6 @@ namespace SevenDigital.Api.Wrapper.Http
 	public interface IHttpClient
 	{
 		Response Get(GetRequest request);
-		void GetAsync(GetRequest request, Action<Response> callback);
-
 		Response Post(PostRequest request);
-		void PostAsync(PostRequest request, Action<Response> callback);
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -15,6 +15,5 @@ namespace SevenDigital.Api.Wrapper
 		IFluentApi<T> UsingCache(IResponseCache responseCache);
 
 		T Please();
-		void PleaseAsync(Action<T> callback);
 	}
 }


### PR DESCRIPTION
One for review - what do you think?

I have deleted all the callback async code from `wrapper.PleaseAsync(x => doSomething(x));` on down because:
- We know that this code is not used by us, probably not used elsewhere, and maintaining it is an overhead.
- If you want to async all the api calls, the async_dotnet45 branch gives you task-basked asynchrony (`async ... await`) and more readable code. Callback async is out of favour in c# now. 

The advantage of the code removed here is that it lets you async _some_ calls, and do it in .net 3.5 not 4.5. But AFAIK nobody is doing that.
