### PR TITLE
Improvements to the nuget package script

### DIFF
--- a/buildpackage/buildPackage.ps1
+++ b/buildpackage/buildPackage.ps1
@@ -3,7 +3,8 @@
 param(
 	[string]$push = "false",
 	[string]$v = "",
-	[string]$prerelease = "false"
+	[string]$prerelease = "false",
+	[string]$source = ""
 )
 
 # functions
@@ -92,8 +93,12 @@ $nuspecWithVersion > SevenDigital.Api.Wrapper.nuspec
 
 nuget pack SevenDigital.Api.Wrapper.nuspec 
 
-$pushCommand = "NuGet Push SevenDigital.Api.Wrapper.#version#.nupkg".Replace("#version#", $fullVersion)
+$pushCommand = "NuGet Push SevenDigital.Api.Wrapper.#version#.nupkg -NonInteractive".Replace("#version#", $fullVersion)
 
+if ($source -ne "")
+{
+  $pushCommand = $pushCommand + " -source $source"
+}
 
 if ($push -eq "true")
 {


### PR DESCRIPTION
Reworked the buildpackaqge script based on work done in https://github.com/AnthonySteele/MvcRouteTester/tree/master/buildpackage
command line options are
"-v a.b.c" manually set a version number. If not used, the version number generated will increment the last part of the latest version on nuget. This switch will be useful when we want to change the major/minor version number.
"-push true" actually push to nuget.org. If not supplied, it will will be a dry run. From experience, the dry run default helps with debugging without slips :P
"-prerelease true" append a "-prerelease" to the version number as per http://docs.nuget.org/docs/reference/versioning#Prerelease_Versions
This allows us to consume the latest version of the code off nuget if we choose, and so test this pre-release code in actual client. Requested strongly by Greg S

This all looks good to me so far but it's hard to test without pushing to nuget. Will try this after merge and fix if needed.
