### PR TITLE
RouteParamsSubstitutor as a non-static class

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/EndpointResolution/RequestHandlers/RouteParamsSubstitutorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/EndpointResolution/RequestHandlers/RouteParamsSubstitutorTests.cs
@@ -31,7 +31,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					Endpoint = "testpath",
 				};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result, Is.Not.Null);
 			Assert.That(result.AbsoluteUrl, Is.Not.Empty);
@@ -51,7 +52,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					}
 			};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result.FullUri, Is.StringContaining("something/routevalue"));
 		}
@@ -71,7 +73,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					}
 			};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result.FullUri, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
@@ -91,7 +94,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					}
 			};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result.FullUri, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
@@ -108,7 +112,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					}
 			};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result.FullUri, Is.StringContaining("something/routevalue"));
 		}
@@ -126,7 +131,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					}
 			};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result.Parameters.ContainsKey("route"), Is.False);
 			Assert.That(result.Parameters.ContainsKey("foo"), Is.True);
@@ -147,7 +153,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.EndpointResolution.RequestHandlers
 					}
 			};
 
-			var result = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
+			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
 			Assert.That(result.Parameters.ContainsKey("firstRoute"), Is.False);
 			Assert.That(result.Parameters.ContainsKey("secondRoute"), Is.False);

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RequestHandler.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RequestHandler.cs
@@ -6,14 +6,14 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 {
 	public class RequestHandler : IRequestHandler
 	{
-		private readonly IApiUri _apiUri;
 		private readonly IOAuthCredentials _oAuthCredentials;
+		private readonly RouteParamsSubstitutor _routeParamsSubstitutor;
 
 		public RequestHandler(IHttpClient httpClient, IApiUri apiUri, IOAuthCredentials oAuthCredentials)
 		{
 			HttpClient = httpClient;
-			_apiUri = apiUri;
 			_oAuthCredentials = oAuthCredentials;
+			_routeParamsSubstitutor = new RouteParamsSubstitutor(apiUri);
 		}
 
 		public IHttpClient HttpClient { get; set; }
@@ -26,8 +26,9 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 
 		private Request BuildRequest(RequestData requestData)
 		{
-			var apiRequest = RouteParamsSubstitutor.SubstituteParamsInRequest(_apiUri, requestData);
+			var apiRequest = _routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 			var fullUrl = apiRequest.AbsoluteUrl;
+
 			var headers = new Dictionary<string, string>(requestData.Headers);
 
 			if (!requestData.RequiresSignature)

--- a/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RouteParamsSubstitutor.cs
+++ b/src/SevenDigital.Api.Wrapper/EndpointResolution/RequestHandlers/RouteParamsSubstitutor.cs
@@ -6,11 +6,18 @@ using SevenDigital.Api.Wrapper.Http;
 
 namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 {
-	public static class RouteParamsSubstitutor
+	public class RouteParamsSubstitutor
 	{
-		public static ApiRequest SubstituteParamsInRequest(IApiUri apiUri, RequestData requestData)
+		private readonly IApiUri _apiUri;
+
+		public RouteParamsSubstitutor(IApiUri apiUri)
 		{
-			var apiBaseUrl = requestData.UseHttps ? apiUri.SecureUri : apiUri.Uri;
+			_apiUri = apiUri;
+		}
+
+		public ApiRequest SubstituteParamsInRequest(RequestData requestData)
+		{
+			var apiBaseUrl = requestData.UseHttps ? _apiUri.SecureUri : _apiUri.Uri;
 
 			var withoutRouteParameters = new Dictionary<string, string>(requestData.Parameters);
 
@@ -37,6 +44,5 @@ namespace SevenDigital.Api.Wrapper.EndpointResolution.RequestHandlers
 
 			return endpointUri.ToLower();
 		}
-
 	}
 }


### PR DESCRIPTION
RouteParamsSubstitutor as a non-static class with dependencies via the constructor to keep it the same as everything else. It's not injected into RequestHandler .. yet
