### PR TITLE
nuspec must show that we now depend on crenna OAuth v1.0.3

### DIFF
--- a/buildpackage/SevenDigital.Api.Wrapper.nuspec.template
+++ b/buildpackage/SevenDigital.Api.Wrapper.nuspec.template
@@ -11,6 +11,7 @@
     <copyright>Copyright 7digital Media Ltd. 2013</copyright>
     <tags>7digital sevendigital music api</tags>
     <dependencies>
+		<dependency id="OAuth" version="1.0.3" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
I noticed this while testing - we now use oauth.dll (Crenna oauth V 1.0.3), so  the .nuspec must show that we now depend on it, so that it will also be installed, or the nuget package install will be left without it and won't work
