### PR TITLE
remove an unused method from ApiRequest

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RouteParamsSubstitutorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RouteParamsSubstitutorTests.cs
@@ -33,7 +33,6 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 
 			Assert.That(result, Is.Not.Null);
 			Assert.That(result.AbsoluteUrl, Is.Not.Empty);
-			Assert.That(result.FullUri, Is.Not.Empty);
 			Assert.That(result.Parameters, Is.Not.Null);
 		}
 
@@ -52,7 +51,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.FullUri, Is.StringContaining("something/routevalue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/routevalue"));
 		}
 
 		[Test]
@@ -73,7 +72,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.FullUri, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
 
 		[Test]
@@ -94,7 +93,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.FullUri, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
 
 		[Test]
@@ -112,7 +111,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.FullUri, Is.StringContaining("something/routevalue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/routevalue"));
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper/Requests/ApiRequest.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/ApiRequest.cs
@@ -1,22 +1,10 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
 
 namespace SevenDigital.Api.Wrapper.Requests
 {
 	public class ApiRequest
 	{
 		public string AbsoluteUrl { get; set; }
-		public Dictionary<string, string> Parameters { get; set; }
-
-		public string FullUri
-		{
-			get
-			{
-				if(Parameters.Any())
-					return AbsoluteUrl + "?" + Parameters.ToQueryString();
-
-				return AbsoluteUrl;
-			}
-		}
+		public IDictionary<string, string> Parameters { get; set; }
 	}
 }


### PR DESCRIPTION
This method is no longer used. 
ApiRequest is still needed, it is just used to return 2 things from RouteParamsSubstitutor - the url with params substituted in, and the remaining params.
