### PR TITLE
Pull WithPayload method up to the interface

### DIFF
--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -11,6 +11,7 @@ namespace SevenDigital.Api.Wrapper
 		IFluentApi<T> UsingClient(IHttpClient httpClient);
 		IFluentApi<T> UsingCache(IResponseCache responseCache);
 		IFluentApi<T> WithMethod(string methodName);
+		IFluentApi<T> WithPayload<TPayload>(TPayload payload) where TPayload : class;
 
 		T Please();
 	}


### PR DESCRIPTION
Forgot to add this in the last PR, it pulls the Generic WithPayload method up to the interface so it can be added at any point of the fluent call. 
