### PR TITLE
#148 Separate Response from Please 

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -267,5 +267,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 
 			A.CallTo(callWithExpectedPayload).MustHaveHappened();
 		}
+
+		[Test]
+		public void Should_allow_you_to_see_the_raw_response_without_parsing()
+		{
+			var requestBuilder = StubRequestBuilder();
+			var httpClient = StubHttpClient();
+
+			var response = new FluentApi<Status>(httpClient, requestBuilder).Response();
+
+			Assert.That(response, Is.Not.Null);
+
+			Assert.That(response.Body, Is.Not.Null);
+			Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -109,29 +109,34 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		} 
 
+		public Response Response()
+		{
+			try
+			{
+				var request = _requestBuilder.BuildRequest(_requestData);
+				return _httpClient.Send(request);
+			}
+			catch (WebException webException)
+			{
+				throw new ApiWebException(webException.Message, EndpointUrl, webException);
+			}
+		}
+
 		public virtual T Please()
 		{
 			Response response;
 
 			var foundInCache = _responseCache.TryGet(_requestData, out response);
-			if (! foundInCache)
+			if (!foundInCache)
 			{
-				try
-				{
-					var request = _requestBuilder.BuildRequest(_requestData);
-					response = _httpClient.Send(request);
-				}
-				catch (WebException webException)
-				{
-					throw new ApiWebException(webException.Message, EndpointUrl, webException);
-				}
+				response = Response();
 			}
 
 			try
 			{
 				var result = _parser.Parse(response);
 
-				// set to cache only after all validation and parsing has suceeded
+				// set to cache only after all validation and parsing has succeeded
 				if (!foundInCache)
 				{
 					_responseCache.Set(_requestData, response);

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -13,6 +13,7 @@ namespace SevenDigital.Api.Wrapper
 		IFluentApi<T> WithMethod(string methodName);
 		IFluentApi<T> WithPayload<TPayload>(TPayload payload) where TPayload : class;
 
+		Response Response();
 		T Please();
 	}
 }


### PR DESCRIPTION
method to allow the raw response object to be returned from the wrapper, this means that `Please()` does both Request-Response and de-serialization of the response, where `Response()` just returns the Response object prior to de-serialization.

This is fully backward compatible, and allows us to deal with many other scenarios than the current "APi returns a response and we de-serialize it" case.
