### PR TITLE
Remove the "ForShop" method from FluentApi

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ArtistEndpoint/ArtistSearchTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ArtistEndpoint/ArtistSearchTests.cs
@@ -1,5 +1,6 @@
 ﻿using NUnit.Framework;
 using SevenDigital.Api.Schema.ArtistEndpoint;
+using SevenDigital.Api.Wrapper.Extensions;
 
 namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.ArtistEndpoint
 {

--- a/src/SevenDigital.Api.Wrapper/Extensions/ShopExtensions.cs
+++ b/src/SevenDigital.Api.Wrapper/Extensions/ShopExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System.Globalization;
+
+namespace SevenDigital.Api.Wrapper.Extensions
+{
+	public static class ShopExtensions
+	{
+		public static IFluentApi<T> ForShop<T>(this IFluentApi<T> api, int shopId)
+		{
+			return api.WithParameter("shopId", shopId.ToString(CultureInfo.InvariantCulture));
+		}
+	}
+}

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -95,12 +95,6 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		}
 
-		public virtual IFluentApi<T> ForShop(int shopId)
-		{
-			WithParameter("shopId", shopId.ToString());
-			return this;
-		}
-
 		public IFluentApi<T> WithPayload(string contentType, string payload)
 		{
 			_requestData.Payload = new RequestPayload(contentType, payload);

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Environment\EssentialDependencyCheck.cs" />
     <Compile Include="Extensions\HasPlaylistIdParameterExtensions.cs" />
     <Compile Include="Extensions\HasPlaylistItemIdParameterExtensions.cs" />
+    <Compile Include="Extensions\ShopExtensions.cs" />
     <Compile Include="Requests\IRequestBuilder.cs" />
     <Compile Include="Requests\RequestBuilder.cs" />
     <Compile Include="Requests\RequestPayload.cs" />


### PR DESCRIPTION
Remove the "ForShop" method from FluentApi as it is almost unused (used in 1 test only) and of little use as it is on the class but not the IFluentApi interface
Re-introduce it as an extension method on all apis
As we use it a fair bit on lots of things
