### PR TITLE
Minor fixes

### DIFF
--- a/buildpackage/SevenDigital.Api.Wrapper.nuspec.template
+++ b/buildpackage/SevenDigital.Api.Wrapper.nuspec.template
@@ -13,7 +13,7 @@
     <tags>7digital sevendigital music api</tags>
     <dependencies>
 		<dependency id="OAuth" version="1.0.3" />
-		<dependency id="Newtonsoft.Json" version="6.0.1" />
+		<dependency id="Newtonsoft.Json" version="6.0.3" />
     </dependencies>
   </metadata>
   <files>

--- a/src/SevenDigital.Api.Schema/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Schema/Properties/AssemblyInfo.cs
@@ -37,5 +37,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]

--- a/src/SevenDigital.Api.Wrapper/Properties/AssemblyInfo.cs
+++ b/src/SevenDigital.Api.Wrapper/Properties/AssemblyInfo.cs
@@ -35,7 +35,7 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyVersion("4.0.0.0")]
+[assembly: AssemblyFileVersion("4.0.0.0")]
 [assembly: InternalsVisibleTo("SevenDigital.Api.Wrapper.Unit.Tests", AllInternalsVisible = true)]
 [assembly: InternalsVisibleTo("SevenDigital.Api.Wrapper.Integration.Tests", AllInternalsVisible = true)]


### PR DESCRIPTION
- after upgrading to .net 4.5, we actually depend on newtonsoft.Json v 6.0.3. The nuspec file should reflect this
- updated the version no in AssembyInfo files for wrapper and schema
