### PR TITLE
Refactor to StringDeserializer:

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Endpoints/Release/ReleaseEndpointTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Endpoints/Release/ReleaseEndpointTests.cs
@@ -18,8 +18,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Endpoints.Release
 			var responseXml = File.ReadAllText("StubResponses/ArtistReleases.xml");
 			var response = new Response(HttpStatusCode.OK, responseXml);
 
-			var xmlParser = new ResponseParser<ArtistReleases>(new ApiResponseDetector());
-			var release =  xmlParser.Parse(response).Releases.First();
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
+			var release = xmlParser.Parse<ArtistReleases>(response).Releases.First();
 
 			Assert.That(release.Type,Is.EqualTo(ReleaseType.Unknown));
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/Payment/CardTypesTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/Payment/CardTypesTests.cs
@@ -17,9 +17,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Parsing.Payment
 		[Test]
 		public void can_deseralize_card_types()
 		{
-			var xmlParser = new ResponseParser<PaymentCardTypes>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var result = xmlParser.Parse(stubResponse);
+			var result = xmlParser.Parse<PaymentCardTypes>(stubResponse);
 
 			Assert.That(result.CardTypes.Count(),Is.EqualTo(4));
 			var lastCard = result.CardTypes.Last();

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/User/Payment/AddCardsTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/User/Payment/AddCardsTests.cs
@@ -31,9 +31,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Parsing.User.Payment
 		[Test]
 		public void can_deserialise_response_user_cards()
 		{
-			var xmlParser = new ResponseParser<Cards>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var deserializedCards = xmlParser.Parse(response);
+			var deserializedCards = xmlParser.Parse<Cards>(response);
 
 			var firstCard = deserializedCards.UserCards[0];
 			Assert.That(deserializedCards.UserCards.Count(), Is.EqualTo(1));

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/User/Payment/Cards_unit_tests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/User/Payment/Cards_unit_tests.cs
@@ -26,9 +26,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Parsing.User.Payment
 		[Test]
 		public void can_deserialise_response_user_cards()
 		{
-			var xmlParser = new ResponseParser<AddCard>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var deserializedCards = xmlParser.Parse(response);
+			var deserializedCards = xmlParser.Parse<AddCard>(response);
 			
 			Assert.That(deserializedCards, Is.Not.Null);
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/User/Payment/DeleteCardTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Parsing/User/Payment/DeleteCardTests.cs
@@ -16,8 +16,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Parsing.User.Payment
 
 			var response = new Response(HttpStatusCode.OK, ResponseXml);
 
-			var xmlParser = new ResponseParser<DeleteCard>(new ApiResponseDetector());
-			var result = xmlParser.Parse(response);
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
+			var result = xmlParser.Parse<DeleteCard>(response);
 
 			Assert.That(result, Is.Not.Null);
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/ResponseParserTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/ResponseParserTests.cs
@@ -14,9 +14,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 		[Test]
 		public void Should_throw_argument_null_exception_when_reponse_is_null()
 		{
-			var apiXmlDeserializer = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var apiXmlDeserializer = new ResponseParser(new ApiResponseDetector());
 
-			Assert.Throws<ArgumentNullException>(() => apiXmlDeserializer.Parse(null));
+			Assert.Throws<ArgumentNullException>(() => apiXmlDeserializer.Parse<TestObject>(null));
 		}
 
 		[Test]
@@ -27,11 +27,11 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 
 			var stubResponse = new Response(HttpStatusCode.OK, xml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			Assert.DoesNotThrow(() => xmlParser.Parse(stubResponse));
+			Assert.DoesNotThrow(() => xmlParser.Parse<TestObject>(stubResponse));
 
-			TestObject testObject = xmlParser.Parse(stubResponse);
+			TestObject testObject = xmlParser.Parse<TestObject>(stubResponse);
 
 			Assert.That(testObject.Id, Is.EqualTo(1));
 		}
@@ -42,9 +42,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string errorXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"1001\"><errorMessage>Test error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.InternalServerError, errorXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<InputParameterException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<InputParameterException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(errorXml));
@@ -58,9 +58,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string errorXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"1001\"><errorMessage>Test error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.OK, errorXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<InputParameterException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<InputParameterException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(errorXml));
@@ -74,9 +74,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string errorXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"2001\"><errorMessage>Test error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.OK, errorXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<InvalidResourceException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<InvalidResourceException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(errorXml));
@@ -90,9 +90,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string errorXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"3001\"><errorMessage>Test error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.OK, errorXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UserCardException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UserCardException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(errorXml));
@@ -106,9 +106,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string errorXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"9001\"><errorMessage>Test error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.OK, errorXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<RemoteApiException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<RemoteApiException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(errorXml));
@@ -122,9 +122,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string errorXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"42\"><errorMessage>Test error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.OK, errorXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(errorXml));
@@ -138,9 +138,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string badError = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error><errorme></errorme></error></response>";
 			var response = new Response(HttpStatusCode.OK, badError);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(response.Body));
@@ -153,9 +153,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			var response = new Response(HttpStatusCode.OK, null);
 
 
-			var xmlSerializer = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlSerializer = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<NonXmlResponseException>(() => xmlSerializer.Parse(response));
+			var ex = Assert.Throws<NonXmlResponseException>(() => xmlSerializer.Parse<TestObject>(response));
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.Null);
 		}
@@ -166,9 +166,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			var response = new Response(HttpStatusCode.OK, string.Empty);
 
 
-			var xmlSerializer = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlSerializer = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<NonXmlResponseException>(() => xmlSerializer.Parse(response));
+			var ex = Assert.Throws<NonXmlResponseException>(() => xmlSerializer.Parse<TestObject>(response));
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.Empty);
 		}
@@ -179,9 +179,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string validXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error><errorMessage>An error</errorMessage></error></response>";
 			var response = new Response(HttpStatusCode.OK, validXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse<TestObject>(response));
 			Assert.That(ex.StatusCode, Is.EqualTo(response.StatusCode));
 			Assert.That(ex.ResponseBody, Is.EqualTo(response.Body));
 			Assert.That(ex.Message, Is.EqualTo(UnrecognisedErrorException.DEFAULT_ERROR_MESSAGE));
@@ -193,9 +193,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string validXml = "<?xml version=\"1.0\" encoding=\"utf-8\" ?><response status=\"error\" version=\"1.2\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"http://api.7digital.com/1.2/static/7digitalAPI.xsd\" ><error code=\"123\"></error></response>";
 			var response = new Response(HttpStatusCode.OK, validXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UnrecognisedErrorException>(() => xmlParser.Parse<TestObject>(response));
 			Assert.That(ex.ResponseBody, Is.EqualTo(response.Body));
 			Assert.That(ex.Message, Is.EqualTo(UnrecognisedErrorException.DEFAULT_ERROR_MESSAGE));
 		}
@@ -207,9 +207,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 
 			var response = new Response(HttpStatusCode.InternalServerError, badXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<NonXmlResponseException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<NonXmlResponseException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo("Response is not xml"));
@@ -224,9 +224,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 
 			var response = new Response(HttpStatusCode.OK, badXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<NonXmlResponseException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<NonXmlResponseException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo("Response is not xml"));
@@ -241,9 +241,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 
 			var response = new Response(HttpStatusCode.OK, badXml);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<NonXmlResponseException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<NonXmlResponseException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo("Response is not xml"));
@@ -257,8 +257,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string ErrorText = "OAuth authentication error: Not authorised - no user credentials provided";
 			var response = new Response(HttpStatusCode.Unauthorized, ErrorText);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
-			var ex = Assert.Throws<OAuthException>(() => xmlParser.Parse(response));
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
+			var ex = Assert.Throws<OAuthException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo(ErrorText));
@@ -272,8 +272,8 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string ErrorText = "OAuth authentication error: Not found";
 			var response = new Response(HttpStatusCode.OK, ErrorText);
 
-			var xmlParser = new ResponseParser<TestObject>(new ApiResponseDetector());
-			var ex = Assert.Throws<OAuthException>(() => xmlParser.Parse(response));
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
+			var ex = Assert.Throws<OAuthException>(() => xmlParser.Parse<TestObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo(ErrorText));
@@ -287,9 +287,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string InvalidStatusXmlResponse = "<?xml version=\"1.0\"?><response status=\"fish\" version=\"1.2\"></response>";
 			var response = new Response(HttpStatusCode.OK, InvalidStatusXmlResponse);
 
-			var xmlParser = new ResponseParser<TestEmptyObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UnrecognisedStatusException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UnrecognisedStatusException>(() => xmlParser.Parse<TestEmptyObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo(UnrecognisedStatusException.DEFAULT_ERROR_MESSAGE));
@@ -303,9 +303,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 			const string MissingStatusXmlResponse = "<?xml version=\"1.0\"?><response version=\"1.2\"></response>";
 			var response = new Response(HttpStatusCode.OK, MissingStatusXmlResponse);
 
-			var xmlParser = new ResponseParser<TestEmptyObject>(new ApiResponseDetector());
+			var xmlParser = new ResponseParser(new ApiResponseDetector());
 
-			var ex = Assert.Throws<UnrecognisedStatusException>(() => xmlParser.Parse(response));
+			var ex = Assert.Throws<UnrecognisedStatusException>(() => xmlParser.Parse<TestEmptyObject>(response));
 
 			Assert.That(ex, Is.Not.Null);
 			Assert.That(ex.Message, Is.EqualTo(UnrecognisedStatusException.DEFAULT_ERROR_MESSAGE));

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/StringDeserializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/StringDeserializerTests.cs
@@ -14,9 +14,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 		[Test]
 		public void should_deserialize_well_formed_xml()
 		{
-			var deserializer = new StringDeserializer<TestObject>();
+			var deserializer = new StringDeserializer();
 
-			var testObject = deserializer.DeserializeApiResponse(TestObjectXmlResponse);
+			var testObject = deserializer.DeserializeApiResponse<TestObject>(TestObjectXmlResponse);
 
 			Assert.That(testObject, Is.Not.Null);
 			Assert.That(testObject.Id, Is.EqualTo(1));
@@ -32,9 +32,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 		[Test]
 		public void should_deserialize_Empty_xml_to_empty_object()
 		{
-			var deserializer = new StringDeserializer<TestEmptyObject>();
+			var deserializer = new StringDeserializer();
 
-			var testObject = deserializer.DeserializeApiResponse(EmptyXmlResponse);
+			var testObject = deserializer.DeserializeApiResponse<TestEmptyObject>(EmptyXmlResponse);
 
 			Assert.That(testObject, Is.Not.Null);
 		}
@@ -42,17 +42,17 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 		[Test]
 		public void should_throw_exception_when_deserialize_into_wrong_type()
 		{
-			var deserializer = new StringDeserializer<Status>();
+			var deserializer = new StringDeserializer();
 
-			Assert.Throws<UnexpectedXmlContentException>(() => deserializer.DeserializeApiResponse(TestObjectXmlResponse));
+			Assert.Throws<UnexpectedXmlContentException>(() => deserializer.DeserializeApiResponse<Status>(TestObjectXmlResponse));
 		}
 
 		[Test]
 		public void should_throw_exception_when_deserialize_into_wrong_type_such_as_one_that_is_not_wrapped_in_a_response_tag()
 		{
-			var deserializer = new StringDeserializer<Status>();
+			var deserializer = new StringDeserializer();
 
-			Assert.Throws<UnexpectedXmlContentException>(() => deserializer.DeserializeApiResponse(TestObjectXmlResponse.Replace("response", "rexponse")));
+			Assert.Throws<UnexpectedXmlContentException>(() => deserializer.DeserializeApiResponse<Status>(TestObjectXmlResponse.Replace("response", "rexponse")));
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Api.cs
+++ b/src/SevenDigital.Api.Wrapper/Api.cs
@@ -2,7 +2,7 @@
 
 namespace SevenDigital.Api.Wrapper
 {
-	public static class Api<T> where T : class
+	public static class Api<T> where T : class, new()
 	{
 		public static IFluentApi<T> Create
 		{

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -13,13 +13,13 @@ using SevenDigital.Api.Wrapper.Responses.Parsing;
 
 namespace SevenDigital.Api.Wrapper
 {
-	public class FluentApi<T> : IFluentApi<T> where T : class
+	public class FluentApi<T> : IFluentApi<T> where T : class, new()
 	{
 		private IHttpClient _httpClient;
 		private readonly IRequestBuilder _requestBuilder;
 
 		private readonly RequestData _requestData;
-		private readonly IResponseParser<T> _parser;
+		private readonly IResponseParser _parser;
 		private IResponseCache _responseCache = new NullResponseCache();
 		private readonly List<IPayloadSerializer> _payloadSerializers= new List<IPayloadSerializer>
 		{
@@ -35,7 +35,7 @@ namespace SevenDigital.Api.Wrapper
 			var attributeValidation = new AttributeRequestDataBuilder<T>();
 			_requestData = attributeValidation.BuildRequestData();
 
-			_parser = new ResponseParser<T>(new ApiResponseDetector());
+			_parser = new ResponseParser(new ApiResponseDetector());
 		}
 
 		public FluentApi(IRequestBuilder requestBuilder) : this(new HttpClientMediator(), requestBuilder)
@@ -139,7 +139,7 @@ namespace SevenDigital.Api.Wrapper
 				response = await Response();
 			}
 
-			var result = _parser.Parse(response);
+			var result = _parser.Parse<T>(response);
 
 				// set to cache only after all validation and parsing has succeeded
 			if (!foundInCache)

--- a/src/SevenDigital.Api.Wrapper/Responses/Parsing/IResponseParser.cs
+++ b/src/SevenDigital.Api.Wrapper/Responses/Parsing/IResponseParser.cs
@@ -1,7 +1,7 @@
 ﻿namespace SevenDigital.Api.Wrapper.Responses.Parsing
 {
-	public interface IResponseParser<out T>
+	public interface IResponseParser
 	{
-		T Parse(Response response);
+		T Parse<T>(Response response) where T : class, new();
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Responses/Parsing/StringDeserializer.cs
+++ b/src/SevenDigital.Api.Wrapper/Responses/Parsing/StringDeserializer.cs
@@ -8,38 +8,47 @@ using SevenDigital.Api.Wrapper.Responses.Parsing.Exceptions;
 
 namespace SevenDigital.Api.Wrapper.Responses.Parsing
 {
-	public class StringDeserializer<T> where T : class
+	public class StringDeserializer 
 	{
-		public T DeserializeApiResponse(string apiResponse)
+		public T DeserializeApiResponse<T>(string apiResponse) where T : class, new()
 		{
 			using (var reader = new StringReader(apiResponse))
 			{
 				XDocument doc;
-				try {
+				try
+				{
 					doc = XDocument.Load(reader);
-				} catch (XmlException e) {
+				}
+				catch (XmlException e)
+				{
 					throw new NonXmlContentException(e);
 				}
 
 				XElement responseNode;
-				try {
+				try
+				{
 					responseNode = doc.Descendants("response").First();
-				} catch (InvalidOperationException e) {
+				}
+				catch (InvalidOperationException e)
+				{
 					throw new UnexpectedXmlContentException(e);
 				}
 
 				var responsePayload = responseNode.FirstNode;
 				if (responsePayload == null)
 				{
-					return (T) Activator.CreateInstance(typeof (T));
+					return new T();
 				}
 
 				using (var payloadReader = responsePayload.CreateReader())
 				{
 					var ser = new XmlSerializer(typeof(T));
-					try {
-						return (T) ser.Deserialize(payloadReader);
-					} catch (InvalidOperationException ex) {
+					try
+					{
+						return (T)ser.Deserialize(payloadReader);
+					}
+					catch (InvalidOperationException ex)
+					{
 						throw new UnexpectedXmlContentException(ex);
 					}
 				}


### PR DESCRIPTION
- resubmitting this
- use new T() not Activator.CreateInstance to make an object
- Add the generic constraint that DTOS much have a parameterless constructor. It did anyway, just not visibly: previous use of Activator.CreateInstance<T>() depended on new() being present. Now we will fail at compiler-time not runtime if it's not there.
- StringDeserializer is generic on the method not the class
- the generic on ResponseParser can also move down to the Parse method
