### PR TITLE
IFluentApi.WithMethod() takes a HttpMethod not a string

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/OAuth/OAuthRequestTokenTest.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/OAuth/OAuthRequestTokenTest.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Net.Http;
+using NUnit.Framework;
 using SevenDigital.Api.Schema.OAuth;
 
 namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.OAuth
@@ -19,7 +20,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.OAuth
 		{
 			var api = (FluentApi<OAuthRequestToken>) Api<OAuthRequestToken>.Create;
 
-			api.WithMethod("POST").WithParameter("one", "two");
+			api.WithMethod(HttpMethod.Post).WithParameter("one", "two");
 
 			var requestToken = await api.Please();
 
@@ -32,7 +33,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.OAuth
 		{
 			var api = (FluentApi<OAuthRequestToken>)Api<OAuthRequestToken>.Create;
 
-			api.WithMethod("POST");
+			api.WithMethod(HttpMethod.Post);
 
 			Assert.DoesNotThrow(async () => await api.Please());
 		}
@@ -54,7 +55,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.OAuth
 		{
 			var api = (FluentApi<OAuthRequestToken>) Api<OAuthRequestToken>.Create;
 
-			api.WithMethod("POST");
+			api.WithMethod(HttpMethod.Post);
 			api.WithParameter("foo", "%! blah"); //arbitrary parameter, but should test for errors in signature generation
 
 			var oAuthRequestToken = await api.Please();

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -61,7 +61,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 			var requestHandler = StubRequestBuilder();
 			var httpClient = StubHttpClient();
 
-			await new FluentApi<Status>(httpClient, requestHandler).WithMethod("POST").Please();
+			await new FluentApi<Status>(httpClient, requestHandler).WithMethod(HttpMethod.Post).Please();
 
 			Expression<Func<Request>> callWithMethodPost =
 				() => requestHandler.BuildRequest(A<RequestData>.That.Matches(x => x.HttpMethod == HttpMethod.Post));
@@ -75,18 +75,10 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 			var requestHandler = A.Fake<IRequestBuilder>();
 			var api = new FluentApi<Status>(requestHandler);
 
-			api.WithMethod("GET");
-			api.WithMethod("POST");
-			api.WithMethod("PUT");
-			api.WithMethod("DELETE");
-		}
-
-		[Test]
-		public void Should_fail_when_http_method_is_unrecognised()
-		{
-			var requestHandler = A.Fake<IRequestBuilder>();
-			var api = new FluentApi<Status>(requestHandler);
-			Assert.Throws<ArgumentException>(() => api.WithMethod("FOO"));
+			api.WithMethod(HttpMethod.Get);
+			api.WithMethod(HttpMethod.Post);
+			api.WithMethod(HttpMethod.Put);
+			api.WithMethod(HttpMethod.Delete);
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 using SevenDigital.Api.Wrapper.Environment;
@@ -72,9 +73,9 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		}
 
-		public virtual IFluentApi<T> WithMethod(string methodName)
+		public virtual IFluentApi<T> WithMethod(HttpMethod httpMethod)
 		{
-			_requestData.HttpMethod =  HttpMethodHelpers.Parse(methodName);
+			_requestData.HttpMethod = httpMethod;
 			return this;
 		}
 

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Net.Http;
+using System.Threading.Tasks;
 using SevenDigital.Api.Wrapper.Http;
 using SevenDigital.Api.Wrapper.Requests.Serializing;
 using SevenDigital.Api.Wrapper.Responses;
@@ -14,7 +15,7 @@ namespace SevenDigital.Api.Wrapper
 		IFluentApi<T> ForUser(string token, string secret);
 		IFluentApi<T> UsingClient(IHttpClient httpClient);
 		IFluentApi<T> UsingCache(IResponseCache responseCache);
-		IFluentApi<T> WithMethod(string methodName);
+		IFluentApi<T> WithMethod(HttpMethod httpMethod);
 		IFluentApi<T> WithPayload<TPayload>(TPayload payload) where TPayload : class;
 		IFluentApi<T> WithPayload<TPayload>(TPayload payload, PayloadFormat payloadSerializer) where TPayload : class;
 


### PR DESCRIPTION
IFluentApi.WithMethod() takes a HttpMethod not a string
For consistency with the rest of the code and for strong typing not string typing
Will break some downstream tests in a minor, easily fixable way
