### PR TITLE
- don't ignore the track preview test, it should pass now

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/TrackEndpoint/TrackPreviewTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/TrackEndpoint/TrackPreviewTests.cs
@@ -6,7 +6,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.TrackEndpoint
 	[TestFixture]
 	public class TrackPreviewTests
 	{
-		[Test, Ignore("Waiting for API fix to reinstate XML declaration")]
+		[Test]
 		public async void Can_hit_endpoint_with_redirect_false()
 		{
 			var request = Api<TrackPreview>.Create
@@ -16,13 +16,6 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.TrackEndpoint
 
 			Assert.That(track, Is.Not.Null);
 			Assert.That(track.Url, Is.EqualTo("http://previews.7digital.com/clips/34/123.clip.mp3"));
-		}
-
-		// TODO
-		[Test, Ignore("Need to implement this")]
-		public void Can_hit_endpoint_with_redirect_true_and_have_the_output_as_a_stream()
-		{
-			Assert.Fail("Not implemented yet");
 		}
 	}
 }


### PR DESCRIPTION
- don't ignore the track preview test, it should pass now
- remove the second test that was just a "todo"

As mentioned in  https://github.com/7digital/SevenDigital.Api.Wrapper/issues/93
