### PR TITLE
Rename "Translations" to "TranslationList"

### DIFF
--- a/src/SevenDigital.Api.Schema/SevenDigital.Api.Schema.csproj
+++ b/src/SevenDigital.Api.Schema/SevenDigital.Api.Schema.csproj
@@ -163,7 +163,7 @@
     <Compile Include="Tracks\TrackSearch.cs" />
     <Compile Include="Tracks\TrackSearchResult.cs" />
     <Compile Include="Tracks\TrackType.cs" />
-    <Compile Include="Translations\Translations.cs" />
+    <Compile Include="Translations\TranslationList.cs" />
     <Compile Include="Users\Payments\Card.cs" />
     <Compile Include="Users\Payments\CardRegistrationDetails.cs" />
     <Compile Include="Users\Payments\CardRegistration.cs" />

--- a/src/SevenDigital.Api.Schema/Translations/TranslationList.cs
+++ b/src/SevenDigital.Api.Schema/Translations/TranslationList.cs
@@ -8,7 +8,7 @@ namespace SevenDigital.Api.Schema.Translations
 	[ApiEndpoint("translations")]
 	[XmlRoot("translations")]
 	[Serializable]
-	public class Translations : HasPaging
+	public class TranslationList : HasPaging
 	{
 		[XmlElement("translation")]
 		public List<Translation> TranslationItems { get; set; }


### PR DESCRIPTION
I noticed that the "Translations" namespace contains a "Translations" class which is the main DTO.
We don't want this name clash, and I took a view that the class could be renamed. 
