### PR TITLE
Provide a method UriPath.Combine for two strings

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/UriPathTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/UriPathTests.cs
@@ -1,0 +1,58 @@
+﻿using NUnit.Framework;
+
+using SevenDigital.Api.Wrapper.Requests;
+
+namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
+{
+	[TestFixture]
+	public class UriPathTests
+	{
+		[Test]
+		public void Should_combine_paths_when_neither_has_slash()
+		{
+			var fullPath = UriPath.Combine("foo", "bar");
+
+			Assert.That(fullPath, Is.EqualTo("foo/bar"));
+		}
+
+		[Test]
+		public void Should_combine_paths_when_first_has_slash()
+		{
+			var fullPath = UriPath.Combine("foo/", "bar");
+
+			Assert.That(fullPath, Is.EqualTo("foo/bar"));
+		}
+
+		[Test]
+		public void Should_combine_paths_when_second_has_slash()
+		{
+			var fullPath = UriPath.Combine("foo", "/bar");
+
+			Assert.That(fullPath, Is.EqualTo("foo/bar"));
+		}
+
+		[Test]
+		public void Should_combine_paths_when_both_have_slashes()
+		{
+			var fullPath = UriPath.Combine("foo/", "/bar");
+
+			Assert.That(fullPath, Is.EqualTo("foo/bar"));
+		}
+
+		[Test]
+		public void Should_cope_with_empty_base()
+		{
+			var fullPath = UriPath.Combine(string.Empty, "foo/bar");
+
+			Assert.That(fullPath, Is.EqualTo("foo/bar"));
+		}
+
+		[Test]
+		public void Should_cope_with_empty_rest()
+		{
+			var fullPath = UriPath.Combine("foo/bar", string.Empty);
+
+			Assert.That(fullPath, Is.EqualTo("foo/bar"));
+		}
+	}
+}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Requests\Serializing\JsonTransferContentTypeTest.cs" />
     <Compile Include="Requests\Serializing\Utf8StringWriterTests.cs" />
     <Compile Include="Requests\Serializing\XmlTransferContentTypeTest.cs" />
+    <Compile Include="Requests\UriPathTests.cs" />
     <Compile Include="Responses\Parsing\ApiResponseDetectorTests.cs" />
     <Compile Include="Responses\Parsing\ResponseParserTests.cs" />
     <Compile Include="Responses\Parsing\TestObject.cs" />

--- a/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
@@ -24,7 +24,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 
 			return new ApiRequest
 			{
-				AbsoluteUrl = string.Format("{0}/{1}", apiBaseUrl, pathWithRouteParamsSubstituted),
+				AbsoluteUrl = UriPath.Combine(apiBaseUrl, pathWithRouteParamsSubstituted),
 				Parameters = withoutRouteParameters
 			};
 		}

--- a/src/SevenDigital.Api.Wrapper/Requests/UriPath.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/UriPath.cs
@@ -1,0 +1,33 @@
+﻿namespace SevenDigital.Api.Wrapper.Requests
+{
+	public static class UriPath
+	{
+		public static string Combine(string baseUri, string rest)
+		{
+			if (string.IsNullOrEmpty(baseUri))
+			{
+				return rest;
+			}
+
+			if (string.IsNullOrEmpty(rest))
+			{
+				return baseUri;
+			}
+
+			bool baseHasTrailingSlash = baseUri.EndsWith("/");
+			bool restHasLeadingSlash = rest.StartsWith("/");
+
+			if (baseHasTrailingSlash && restHasLeadingSlash)
+			{
+				return baseUri.Substring(0, baseUri.Length - 1) + rest;
+			}
+
+			if (baseHasTrailingSlash || restHasLeadingSlash)
+			{
+				return baseUri + rest;
+			}
+
+			return baseUri + "/" + rest;
+		}
+	}
+}

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Requests\Serializing\PayloadFormat.cs" />
     <Compile Include="Requests\Serializing\Utf8StringWriter.cs" />
     <Compile Include="Requests\Serializing\XmlPayloadSerializer.cs" />
+    <Compile Include="Requests\UriPath.cs" />
     <Compile Include="Responses\IResponseCache.cs" />
     <Compile Include="Responses\NullResponseCache.cs" />
     <Compile Include="Requests\Request.cs" />


### PR DESCRIPTION
Provide a method UriPath.Combine for two strings, which is forgiving of whether one, both or neither have slash in the middle.
Fix to: https://github.com/7digital/SevenDigital.Api.Wrapper/issues/204
