### PR TITLE
Remove IFluentApi.ClearParameters()

### DIFF
--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -95,12 +95,6 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		}
 
-		public IFluentApi<T> ClearParameters()
-		{
-			_requestData.Parameters.Clear();
-			return this;
-		}
-
 		public IFluentApi<T> ForUser(string oAuthToken, string oAuthTokenSecret)
 		{
 			_requestData.OAuthToken = oAuthToken;

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -12,7 +12,6 @@ namespace SevenDigital.Api.Wrapper
 		string EndpointUrl { get; }
 
 		IFluentApi<T> WithParameter(string key, string value);
-		IFluentApi<T> ClearParameters();
 		IFluentApi<T> ForUser(string oAuthToken, string oAuthTokenSecret);
 		IFluentApi<T> UsingClient(IHttpClient httpClient);
 		IFluentApi<T> UsingCache(IResponseCache responseCache);


### PR DESCRIPTION
It's not used in this lib and clients using it is an antipattern - should use a new request each time
