### PR TITLE
Having a try at post body as form-url encoded

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderOAuthHeaderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderOAuthHeaderTests.cs
@@ -1,4 +1,6 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
+using System.Net.Http;
+using NUnit.Framework;
 using SevenDigital.Api.Wrapper.Requests;
 
 namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
@@ -77,6 +79,47 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 
 			Assert.That(actual, Is.Not.StringContaining("oauth_token"));
 			Assert.That(actual, Is.StringContaining("oauth_consumer_key="));
+		}
+
+		[Test]
+		public void Should_include_request_params()
+		{
+			var requestData = new RequestData
+			{
+				HttpMethod = HttpMethod.Get,
+				Endpoint = "http://api.com/endpoint",
+				Parameters = new Dictionary<string, string>
+					{
+						{ "a", "b" },
+						{ "c", "d" }
+					},
+				RequiresSignature = true,
+				OAuthToken = "TOKEN",
+				OAuthTokenSecret = "SECRET",
+				Payload = null
+			};
+
+			var actual = GetAuthHeader(requestData);
+
+			Assert.That(actual, Is.StringContaining("oauth_token="));
+		}
+
+		[Test]
+		public void Should_include_form_url_encoded_post_body()
+		{
+			var requestData = new RequestData
+			{
+				HttpMethod = HttpMethod.Post,
+				Endpoint = "http://api.com/endpoint",
+				Payload = new RequestPayload("application/x-www-form-urlencoded", "a=b&c=d"),
+				RequiresSignature = true,
+				OAuthToken = "TOKEN",
+				OAuthTokenSecret = "SECRET"
+			};
+
+			var actual = GetAuthHeader(requestData);
+
+			Assert.That(actual, Is.StringContaining("oauth_token="));
 		}
 
 		private string GetAuthHeader(RequestData requestData)

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderOAuthHeaderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderOAuthHeaderTests.cs
@@ -122,6 +122,24 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			Assert.That(actual, Is.StringContaining("oauth_token="));
 		}
 
+		[Test]
+		public void Should_not_include_json_post_body()
+		{
+			var requestData = new RequestData
+			{
+				HttpMethod = HttpMethod.Post,
+				Endpoint = "http://api.com/endpoint",
+				Payload = new RequestPayload("application/json", "{ a: 1, c: 2 }"),
+				RequiresSignature = true,
+				OAuthToken = "TOKEN",
+				OAuthTokenSecret = "SECRET"
+			};
+
+			var actual = GetAuthHeader(requestData);
+
+			Assert.That(actual, Is.StringContaining("oauth_token="));
+		}
+
 		private string GetAuthHeader(RequestData requestData)
 		{
 			var request = _requestBuilder.BuildRequest(requestData);

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
@@ -14,13 +14,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 	[TestFixture]
 	public class FormUrlEncodedPayloadSerializerTests
 	{
-		private FormUrlEncodedPayloadSerializer _payloadSerializer;
-
-		[SetUp]
-		public void SetUp()
-		{
-			_payloadSerializer = new FormUrlEncodedPayloadSerializer();
-		}
+		private readonly FormUrlEncodedPayloadSerializer _payloadSerializer = new FormUrlEncodedPayloadSerializer();
 
 		[Test]
 		public void Should_have_correct_contenttype()

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Web;
 using NUnit.Framework;
 using SevenDigital.Api.Schema.Artists;
 using SevenDigital.Api.Wrapper.Requests.Serializing;
@@ -68,6 +69,23 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 			var actual = _payloadSerializer.Serialize(data);
 
 			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
+		}
+
+		[Test]
+		public void Should_produce_parsable_output()
+		{
+			var data = new DataWithIntValues
+			{
+				Name = "test data",
+				Values = new List<int> { 1, 2, 12345 }
+			};
+
+			var actual = _payloadSerializer.Serialize(data);
+			var decoded = HttpUtility.ParseQueryString(actual);
+
+			Assert.That(decoded.Count, Is.EqualTo(2));
+			Assert.That(decoded["Name"], Is.EqualTo("test data"));
+			Assert.That(decoded["Values"], Is.EqualTo("1,2,12345"));
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using NUnit.Framework;
+using SevenDigital.Api.Schema.Artists;
+using SevenDigital.Api.Wrapper.Requests.Serializing;
+
+namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
+{
+	public class DataWithIntValues
+	{
+		public string Name { get; set; }
+		public List<int> Values { get; set; }
+	}
+
+	[TestFixture]
+	public class FormUrlEncodedPayloadSerializerTests
+	{
+		private FormUrlEncodedPayloadSerializer _payloadSerializer;
+
+		[SetUp]
+		public void SetUp()
+		{
+			_payloadSerializer = new FormUrlEncodedPayloadSerializer();
+		}
+
+		[Test]
+		public void Should_have_correct_contenttype()
+		{
+			Assert.That(_payloadSerializer.ContentType, Is.EqualTo("application/x-www-form-urlencoded"));
+		}
+
+		[Test]
+		public void Should_serialize_artist_as_expected()
+		{
+			const string expectedEncodedOutput = "Id=143451&Name=MGMT&AppearsAs=MGMT&Image=http%3A%2F%2Fcdn.7static.com%2Fstatic%2Fimg%2Fartistimages%2F00%2F001%2F434%2F0000143451_150.jpg&Url=http%3A%2F%2Fwww.7digital.com%2Fartist%2Fmgmt%2F%3Fpartner%3D1401";
+
+			var artist = new Artist
+			{
+				AppearsAs = "MGMT",
+				Name = "MGMT",
+				Id = 143451,
+				Image = "http://cdn.7static.com/static/img/artistimages/00/001/434/0000143451_150.jpg",
+				Url = "http://www.7digital.com/artist/mgmt/?partner=1401"
+			};
+
+			var actual = _payloadSerializer.Serialize(artist);
+
+			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
+		}
+
+
+		[Test]
+		public void Should_serialize_data_with_ints_as_expected()
+		{
+			const string expectedEncodedOutput = "Name=test%20data&Values=1%2C2%2C12345";
+
+			var data = new DataWithIntValues
+			{
+				Name = "test data",
+				Values = new List<int> {1, 2, 12345}
+			};
+
+			var actual = _payloadSerializer.Serialize(data);
+
+			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
+		}
+	}
+}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
@@ -11,6 +11,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 		public List<int> Values { get; set; }
 	}
 
+	public class WidgetOwner
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+		public Widget Widget { get; set; }
+	}
+
+	public class Widget
+	{
+		public int Id { get; set; }
+		public string Name { get; set; }
+	}
+
 	[TestFixture]
 	public class FormUrlEncodedPayloadSerializerTests
 	{
@@ -41,7 +54,6 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
 		}
 
-
 		[Test]
 		public void Should_serialize_data_with_ints_as_expected()
 		{
@@ -54,6 +66,23 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 			};
 
 			var actual = _payloadSerializer.Serialize(data);
+
+			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
+		}
+
+		[Test]
+		public void Should_not_serialize_nulls()
+		{
+			const string expectedEncodedOutput = "Id=12&Name=fred";
+
+			var dataWithNull = new WidgetOwner
+				{
+					Id = 12,
+					Name = "fred",
+					Widget = null
+				};
+
+			var actual = _payloadSerializer.Serialize(dataWithNull);
 
 			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/FormUrlEncodedPayloadSerializerTests.cs
@@ -17,12 +17,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 		public int Id { get; set; }
 		public string Name { get; set; }
 		public Widget Widget { get; set; }
+
+		public int? OptionalInt { get; set; }
 	}
 
 	public class Widget
 	{
-		public int Id { get; set; }
-		public string Name { get; set; }
 	}
 
 	[TestFixture]
@@ -97,8 +97,28 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 				{
 					Id = 12,
 					Name = "fred",
-					Widget = null
+					Widget = null,
+					OptionalInt = null
 				};
+
+			var actual = _payloadSerializer.Serialize(dataWithNull);
+
+			Assert.That(actual, Is.EqualTo(expectedEncodedOutput));
+		}
+
+
+		[Test]
+		public void Should_serialize_nullable_with_value()
+		{
+			const string expectedEncodedOutput = "Id=12&Name=fred&OptionalInt=34";
+
+			var dataWithNull = new WidgetOwner
+			{
+				Id = 12,
+				Name = "fred",
+				Widget = null,
+				OptionalInt = 34
+			};
 
 			var actual = _payloadSerializer.Serialize(dataWithNull);
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/JsonPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/JsonPayloadSerializerTests.cs
@@ -5,15 +5,9 @@ using SevenDigital.Api.Wrapper.Requests.Serializing;
 namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 {
 	[TestFixture]
-	public class JsonTransferContentTypeTest
+	public class JsonPayloadSerializerTests
 	{
-		private JsonPayloadSerializer _payloadSerializer;
-
-		[SetUp]
-		public void SetUp()
-		{
-			_payloadSerializer = new JsonPayloadSerializer();
-		}
+		private readonly JsonPayloadSerializer _payloadSerializer = new JsonPayloadSerializer();
 
 		[Test]
 		public void Should_have_correct_contenttype()

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/XmlPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/XmlPayloadSerializerTests.cs
@@ -5,15 +5,9 @@ using SevenDigital.Api.Wrapper.Requests.Serializing;
 namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 {
 	[TestFixture]
-	public class XmlTransferContentTypeTest
+	public class XmlPayloadSerializerTests
 	{
-		private XmlPayloadSerializer _payloadSerializer;
-
-		[SetUp]
-		public void SetUp()
-		{
-			_payloadSerializer = new XmlPayloadSerializer();
-		}
+		private readonly XmlPayloadSerializer _payloadSerializer = new XmlPayloadSerializer();
 
 		[Test]
 		public void Should_have_correct_contenttype()

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/XmlTransferContentTypeTest.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/XmlTransferContentTypeTest.cs
@@ -16,13 +16,13 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 		}
 
 		[Test]
-		public void SHould_have_correct_contenttype()
+		public void Should_have_correct_contenttype()
 		{
 			Assert.That(_payloadSerializer.ContentType, Is.EqualTo("application/xml"));
 		}
 
 		[Test]
-		public void SHould_serialize_artist_as_expected()
+		public void Should_serialize_artist_as_expected()
 		{
 			const string expectedXmlOutput = "<?xml version=\"1.0\" encoding=\"utf-8\"?><artist id=\"143451\"><name>MGMT</name><appearsAs>MGMT</appearsAs><image>http://cdn.7static.com/static/img/artistimages/00/001/434/0000143451_150.jpg</image><url>http://www.7digital.com/artist/mgmt/?partner=1401</url></artist>";
 			

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -58,6 +58,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Net.Http" />
+    <Reference Include="System.Web" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -100,6 +100,7 @@
     <Compile Include="Http\FakeHttpClient.cs" />
     <Compile Include="Requests\RequestBuilderTests.cs" />
     <Compile Include="Requests\DictionaryExtensionsTests.cs" />
+    <Compile Include="Requests\Serializing\FormUrlEncodedPayloadSerializerTests.cs" />
     <Compile Include="Requests\Serializing\HalLinkCollectionConverterTests.cs" />
     <Compile Include="Requests\Serializing\JsonTransferContentTypeTest.cs" />
     <Compile Include="Requests\Serializing\Utf8StringWriterTests.cs" />

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -102,9 +102,9 @@
     <Compile Include="Requests\DictionaryExtensionsTests.cs" />
     <Compile Include="Requests\Serializing\FormUrlEncodedPayloadSerializerTests.cs" />
     <Compile Include="Requests\Serializing\HalLinkCollectionConverterTests.cs" />
-    <Compile Include="Requests\Serializing\JsonTransferContentTypeTest.cs" />
+    <Compile Include="Requests\Serializing\JsonPayloadSerializerTests.cs" />
     <Compile Include="Requests\Serializing\Utf8StringWriterTests.cs" />
-    <Compile Include="Requests\Serializing\XmlTransferContentTypeTest.cs" />
+    <Compile Include="Requests\Serializing\XmlPayloadSerializerTests.cs" />
     <Compile Include="Requests\UriPathTests.cs" />
     <Compile Include="Responses\Parsing\ApiResponseDetectorTests.cs" />
     <Compile Include="Responses\Parsing\ResponseParserTests.cs" />

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -23,10 +23,11 @@ namespace SevenDigital.Api.Wrapper
 		private readonly IResponseParser _parser;
 		private IResponseCache _responseCache = new NullResponseCache();
 		private readonly List<IPayloadSerializer> _payloadSerializers= new List<IPayloadSerializer>
-		{
-			new XmlPayloadSerializer(),
-			new JsonPayloadSerializer()
-		};
+			{
+				new XmlPayloadSerializer(),
+				new JsonPayloadSerializer(),
+				new FormUrlEncodedPayloadSerializer()
+			};
 
 		public FluentApi(IHttpClient httpClient, IRequestBuilder requestBuilder, IResponseParser responseParser)
 		{

--- a/src/SevenDigital.Api.Wrapper/Requests/Serializing/FormUrlEncodedPayloadSerializer.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/Serializing/FormUrlEncodedPayloadSerializer.cs
@@ -49,6 +49,7 @@ namespace SevenDigital.Api.Wrapper.Requests.Serializing
 				var valueElemType = valueType.IsGenericType
 					? valueType.GetGenericArguments()[0]
 					: valueType.GetElementType();
+
 				if (valueElemType.IsPrimitive || valueElemType == typeof(string))
 				{
 					var enumerable = properties[key] as IEnumerable;
@@ -57,10 +58,12 @@ namespace SevenDigital.Api.Wrapper.Requests.Serializing
 			}
 
 			// Concat all key/value pairs into a string separated by ampersand
-			return string.Join("&", properties
-				.Select(x => string.Concat(
-					Uri.EscapeDataString(x.Key), "=",
-					Uri.EscapeDataString(x.Value.ToString()))));
+			var pairs = properties.Select(x =>
+				string.Concat(
+					Uri.EscapeDataString(x.Key), "=", 
+					Uri.EscapeDataString(x.Value.ToString())));
+
+			return string.Join("&", pairs);
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Requests/Serializing/FormUrlEncodedPayloadSerializer.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/Serializing/FormUrlEncodedPayloadSerializer.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections;
+using System.Linq;
+
+namespace SevenDigital.Api.Wrapper.Requests.Serializing
+{
+	public class FormUrlEncodedPayloadSerializer : IPayloadSerializer
+	{
+		public PayloadFormat Handles
+		{
+			get { return PayloadFormat.FormUrlEncoded; }
+		}
+
+		public string ContentType
+		{
+			get { return "application/x-www-form-urlencoded"; }
+		}
+
+		public string Serialize<TPayload>(TPayload payload) where TPayload : class
+		{
+			return SerialiseWithRefection(payload);
+		}
+
+		/// <summary>
+		/// Code to "Serialize object into a query string with Reflection" by Ole Michelsen 2012
+		/// Will do most poco objects
+		///  http://ole.michelsen.dk/blog/serialize-object-into-a-query-string-with-reflection.html
+		/// </summary>
+		/// <param name="request"></param>
+		/// <returns></returns>
+		private string SerialiseWithRefection(object request)
+		{
+			// Get all properties on the object
+			var properties = request.GetType().GetProperties()
+				.Where(x => x.CanRead)
+				.Where(x => x.GetValue(request, null) != null)
+				.ToDictionary(x => x.Name, x => x.GetValue(request, null));
+
+			// Get names for all IEnumerable properties (excl. string)
+			var propertyNames = properties
+				.Where(x => !(x.Value is string) && x.Value is IEnumerable)
+				.Select(x => x.Key)
+				.ToList();
+
+			// Concat all IEnumerable properties into a comma separated string
+			foreach (var key in propertyNames)
+			{
+				var valueType = properties[key].GetType();
+				var valueElemType = valueType.IsGenericType
+					? valueType.GetGenericArguments()[0]
+					: valueType.GetElementType();
+				if (valueElemType.IsPrimitive || valueElemType == typeof(string))
+				{
+					var enumerable = properties[key] as IEnumerable;
+					properties[key] = string.Join(",", enumerable.Cast<object>());
+				}
+			}
+
+			// Concat all key/value pairs into a string separated by ampersand
+			return string.Join("&", properties
+				.Select(x => string.Concat(
+					Uri.EscapeDataString(x.Key), "=",
+					Uri.EscapeDataString(x.Value.ToString()))));
+		}
+	}
+}

--- a/src/SevenDigital.Api.Wrapper/Requests/Serializing/PayloadFormat.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/Serializing/PayloadFormat.cs
@@ -3,6 +3,7 @@
 	public enum PayloadFormat
 	{
 		Xml,
-		Json
+		Json,
+		FormUrlEncoded
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -111,6 +111,7 @@
     <Compile Include="Extensions\HasUserDeliverItemParameterExtensions.cs" />
     <Compile Include="Extensions\LockerSortColumn.cs" />
     <Compile Include="Extensions\SortOrder.cs" />
+    <Compile Include="Requests\Serializing\FormUrlEncodedPayloadSerializer.cs" />
     <Compile Include="Requests\Serializing\HalLinkCollectionConverter.cs" />
     <Compile Include="Requests\Serializing\IPayloadSerializer.cs" />
     <Compile Include="Requests\Serializing\JsonPayloadSerializer.cs" />


### PR DESCRIPTION
We need to send some posts as form-url-encoded data
This should allow it. Will test more thoroughly after lunch
Code from http://ole.michelsen.dk/blog/serialize-object-into-a-query-string-with-reflection.html

Advantage of form-url-encoded data is that the body is used in the OAuth signing, so it can't be changed without the request being rejected.