### PR TITLE
Removed the code in buildPackage.ps1 that guesses a next version number

### DIFF
--- a/buildpackage/buildPackage.ps1
+++ b/buildpackage/buildPackage.ps1
@@ -20,41 +20,6 @@ function BuildSolution
   C:\Windows\Microsoft.NET\Framework64\v4.0.30319\MSBuild.exe ..\SevenDigital.Api.Wrapper.sln /t:build /p:Configuration=Debug
 }
 
-function GetLatestFullVersionOnNuget()
-{
-  [CmdletBinding()]
-  param()
-
-   $packageDetails = &nuget list SevenDigital.Api.Wrapper
-   $lineParts = $packageDetails.Split(' ')
-   [string]$lineParts[1]
-}
-
-function GetLastVersionNumber()
-{
-  [CmdletBinding()]
-  param()
-
-  $fullVersionString = GetLatestFullVersionOnNuget
-  $versionParts = $fullVersionString.Split('.')
-  $versionParts
-}
-
-function NextFullVersion()
-{
-  [CmdletBinding()]
-  param()
-  
-  $parts = GetLastVersionNumber
-  $lastPart = $parts[2]
-  $newVersion = [int]$lastPart + 1 
-  
-  $parts[2] = [string]$newVersion
-  
-  $newVersion = [string]::Join(".", $parts)
-  $newVersion
-}
-
 function CleanupBuildArtifacts
 {
   [CmdletBinding()]
@@ -71,9 +36,8 @@ BuildSolution
 $fullVersion = $v
 if ($fullVersion -eq "")
 {
-  write-output "Reading package version from nuget..."
-  $fullVersion = NextFullVersion 
-  write-output "Next package version from nuget: $fullVersion"
+  write-output "You must specify a version number with '-v' "
+  exit
 }
 else
 {


### PR DESCRIPTION
It did this by incrementing the last digit.

- this is often not the number that we want as it always just increments the last digit.
- we don't do this every day, can work out what version number we want when we come to release.
- it sometimes fails due to timeout.

So it's more trouble than it's worth. Insist that a version number is specified when running the script.