### PR TITLE
Update to latest schema, which is not a portable class lib

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.1.0\lib\portable-net4+sl4+wp71+windows8\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.2.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/packages.config
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.1.0" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.2.1" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -50,7 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.1.0\lib\portable-net4+sl4+wp71+windows8\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.2.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/packages.config
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/packages.config
@@ -3,5 +3,5 @@
   <package id="FakeItEasy" version="1.25.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.1.0" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.2.1" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -45,7 +45,7 @@
       <HintPath>..\..\packages\OAuth.1.0.3\lib\net40\OAuth.dll</HintPath>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.1.0\lib\portable-net4+sl4+wp71+windows8\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.2.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper/packages.config
+++ b/src/SevenDigital.Api.Wrapper/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
   <package id="OAuth" version="1.0.3" targetFramework="net40" />
-  <package id="SevenDigital.Api.Schema" version="1.1.0" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.2.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update to schema version.
We don't have to update for every schema version, and we don't for this version either.
However it was worth testing the schema's move from PCL back to regular .Net class lib
IMHO this is worth merging for future use, but not worth re-releasing the wrapper for.

-- This is OK to merge now