### PR TITLE
Update dependencies from nuget

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
@@ -38,8 +38,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.2.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.3.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/packages.config
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.2.1" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -37,12 +37,12 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FakeItEasy, Version=1.25.2.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FakeItEasy.1.25.2\lib\net40\FakeItEasy.dll</HintPath>
+    <Reference Include="FakeItEasy, Version=1.25.3.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FakeItEasy.1.25.3\lib\net40\FakeItEasy.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
@@ -50,7 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.2.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.3.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/StubRequests/Playlist.xml
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/StubRequests/Playlist.xml
@@ -2,6 +2,7 @@
 <playlist>
 	<name>Test Playlist</name>
 	<visibility>Private</visibility>
+	<status>NotSpecified</status>
 	<tracks>
 		<trackId>123</trackId>
 		<trackTitle>Weekend Wars</trackTitle>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/packages.config
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FakeItEasy" version="1.25.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="FakeItEasy" version="1.25.3" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.2.1" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.3.1" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -37,15 +37,15 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="OAuth">
       <HintPath>..\..\packages\OAuth.1.0.3\lib\net40\OAuth.dll</HintPath>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.2.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.3.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper/packages.config
+++ b/src/SevenDigital.Api.Wrapper/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="OAuth" version="1.0.3" targetFramework="net40" />
-  <package id="SevenDigital.Api.Schema" version="1.2.1" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.3.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Just an update of dependencies: chiefly that  Newtonsoft.Json is V7.0 
Some other things are now using Newtonsoft.Json V7.0
so this was requiring an assembly binding redirect