### PR TITLE
Update deps part 2: nuget package should specify new min versions

### DIFF
--- a/buildpackage/SevenDigital.Api.Wrapper.nuspec.template
+++ b/buildpackage/SevenDigital.Api.Wrapper.nuspec.template
@@ -13,8 +13,8 @@
     <tags>7digital sevendigital music api</tags>
     <dependencies>
 		<dependency id="OAuth" version="1.0.3" />
-		<dependency id="Newtonsoft.Json" version="6.0.3" />
-		<dependency id="SevenDigital.Api.Schema" version="1.0.0" />
+		<dependency id="Newtonsoft.Json" version="7.0.1" />
+		<dependency id="SevenDigital.Api.Schema" version="1.3.1" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
nuget package for api wrapper should specify new min versions of upstream packages