### PR TITLE
Adds a traceId header to each request 

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/StatusTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/StatusTests.cs
@@ -23,8 +23,26 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests
 			var status = await Api<Status>.Create.Response();
 
 			var traceId = status.OriginalRequest.TraceId;
+			Assert.That(traceId, Is.Not.Null);
+			Assert.DoesNotThrow(() => Guid.Parse(traceId));
+		}
+
+		[Test]
+		public async void Two_separate_requests_get_different_traceIds()
+		{
+			var fluentApi = Api<Status>.Create;
+			var status = await fluentApi.Response();
+			var status2 = await fluentApi.Response();
+
+			var traceId = status.OriginalRequest.TraceId;
+			var traceId2 = status2.OriginalRequest.TraceId;
 			Assert.That(status.OriginalRequest.TraceId, Is.Not.Null);
 			Assert.DoesNotThrow(() => Guid.Parse(traceId));
+
+			Assert.That(status.OriginalRequest.TraceId, Is.Not.Null);
+			Assert.DoesNotThrow(() => Guid.Parse(traceId2));
+
+			Assert.That(traceId, Is.Not.EqualTo(traceId2));
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/StatusTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/StatusTests.cs
@@ -16,5 +16,24 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests
 			Assert.That(status, Is.Not.Null);
 			Assert.That(status.ServerTime.Day, Is.EqualTo(DateTime.Now.Day));
 		}
+
+		[Test]
+		public async void Can_see_default_traceId_as_guid_parseable_string()
+		{
+			var status = await Api<Status>.Create.Response();
+
+			var traceId = status.OriginalRequest.TraceId;
+			Assert.That(status.OriginalRequest.TraceId, Is.Not.Null);
+			Assert.DoesNotThrow(() => Guid.Parse(traceId));
+		}
+
+		[Test]
+		public async void Can_see_custom_traceId()
+		{
+			var customTraceId = Guid.NewGuid().ToString();
+			var status = await Api<Status>.Create.WithTraceId(customTraceId).Response();
+
+			Assert.That(status.OriginalRequest.TraceId, Is.EqualTo(customTraceId));
+		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/StatusTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/StatusTests.cs
@@ -53,5 +53,19 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests
 
 			Assert.That(status.OriginalRequest.TraceId, Is.EqualTo(customTraceId));
 		}
+
+		[Test]
+		public async void Can_specify_2_different_trace_ids_on_different_requests()
+		{
+			var customTraceId1 = Guid.NewGuid().ToString();
+			var customTraceId2 = Guid.NewGuid().ToString();
+
+			var fluentApi = Api<Status>.Create;
+			var status = await fluentApi.WithTraceId(customTraceId1).Response();
+			var status2 = await fluentApi.WithTraceId(customTraceId2).Response();
+
+			Assert.That(status.OriginalRequest.TraceId, Is.EqualTo(customTraceId1));
+			Assert.That(status2.OriginalRequest.TraceId, Is.EqualTo(customTraceId2));
+		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/Http/HttpClientMediatorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/Http/HttpClientMediatorTests.cs
@@ -25,7 +25,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 		public async void Can_resolve_uri()
 		{
 			var url = string.Format("{0}/status?oauth_consumer_key={1}", API_URL, _consumerKey);
-			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null);
+			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null, null);
 
 			var response = await new HttpClientMediator().Send(request);
 			AssertResponse(response, HttpStatusCode.OK);
@@ -35,7 +35,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 		public async void Can_resolve_uri_that_returns_gzip()
 		{
 			var url = string.Format("{0}/release/details?oauth_consumer_key={1}&releaseId=12345", API_URL, _consumerKey);
-			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null);
+			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null, null);
 
 			var response = await new HttpClientMediator().Send(request);
 			AssertResponse(response, HttpStatusCode.OK);
@@ -60,7 +60,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 		public async void Bad_url_should_return_not_found()
 		{
 			var url = string.Format("{0}/foo/bar/fish/1234?oauth_consumer_key={1}", API_URL, _consumerKey);
-			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null);
+			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null, null);
 
 			var response = await new HttpClientMediator().Send(request);
 			AssertResponse(response, HttpStatusCode.NotFound);
@@ -70,7 +70,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 		public async void No_key_should_return_unauthorized()
 		{
 			var url = string.Format("{0}/status", API_URL);
-			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null);
+			var request = new Request(HttpMethod.Get, url, new Dictionary<string, string>(), null, null);
 
 			var response = await new HttpClientMediator().Send(request);
 			AssertResponse(response, HttpStatusCode.Unauthorized);
@@ -83,7 +83,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 		public async void Can_cope_with_timeouts()
 		{
 			const string apiUrl = "http://hanging-web-app.7digital.local";
-			var request = new Request(HttpMethod.Post, apiUrl, new Dictionary<string, string>(), null);
+			var request = new Request(HttpMethod.Post, apiUrl, new Dictionary<string, string>(), null, null);
 
 			var response = await new HttpClientMediator().Send(request);
 			AssertResponse(response, HttpStatusCode.OK);
@@ -101,7 +101,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 
 			var queryString = parameters.ToQueryString();
 			var requestPayload = new RequestPayload("application/xml", queryString);
-			var request = new Request(HttpMethod.Post, url, new Dictionary<string, string>(), requestPayload);
+			var request = new Request(HttpMethod.Post, url, new Dictionary<string, string>(), requestPayload, null);
 
 			var response = await new HttpClientMediator().Send(request);
 			AssertResponse(response, HttpStatusCode.NotFound);
@@ -122,7 +122,8 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			{
 				{"headerKey", "headerValue"}
 			};
-			var originalRequest = new Request(HttpMethod.Post, url, expectedHeaders, requestPayload);
+			const string expectedTraceId = "CUSTOM_TRACE_ID";
+			var originalRequest = new Request(HttpMethod.Post, url, expectedHeaders, requestPayload, expectedTraceId);
 
 			var response = await new HttpClientMediator().Send(originalRequest);
 
@@ -130,6 +131,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.Http
 			Assert.That(response.OriginalRequest.Headers, Is.EqualTo(expectedHeaders));
 			Assert.That(response.OriginalRequest.Body, Is.EqualTo(requestPayload));
 			Assert.That(response.OriginalRequest.Method, Is.EqualTo(HttpMethod.Post));
+			Assert.That(response.OriginalRequest.TraceId, Is.EqualTo(expectedTraceId));
 		}
 
 		private static void AssertResponse(Response response, HttpStatusCode expectedCode)

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Exceptions/ApiWebExceptionTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Exceptions/ApiWebExceptionTests.cs
@@ -80,7 +80,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Exceptions
 			var requestBody = new RequestPayload("foo", "bar");
 			var headers = new Dictionary<string, string> {{"key1", "value1"}};
 			var originalRequest = new Request(HttpMethod.Get, "http://foo.com/bar?foo=bar",
-				headers, requestBody);
+				headers, requestBody, null);
 
 			var inputException = new ApiWebException("request failed", innerException, originalRequest);
 			return inputException;

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -395,5 +395,19 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 
 			A.CallTo(() => requestBuilder.BuildRequest(A<RequestData>.That.Matches(x => x.TraceId == customTraceID))).MustHaveHappened();
 		}
+
+		[Test]
+		public void Empty_traceId_should_throw_exception()
+		{
+			var requestBuilder = StubRequestBuilder();
+			var httpClient = StubHttpClient();
+			var responseParser = StubResponseParser();
+
+			const string customTraceID = "";
+
+			var argumentException = Assert.Throws<ArgumentNullException>(async () => await new FluentApi<Status>(httpClient, requestBuilder, responseParser).WithTraceId(customTraceID).Please());
+
+			Assert.That(argumentException.ParamName, Is.EqualTo("traceId"));
+		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -379,5 +379,21 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 
 			A.CallTo(callWithExpectedPayload).MustHaveHappened();
 		}
+
+		[Test]
+		public async void Should_allow_you_to_specify_custom_traceId()
+		{
+			var requestBuilder = StubRequestBuilder();
+			var httpClient = StubHttpClient();
+			var responseParser = StubResponseParser();
+
+			const string customTraceID = "CUSTOM_TRACE_ID";
+
+			await new FluentApi<Status>(httpClient, requestBuilder, responseParser)
+				.WithTraceId(customTraceID)
+				.Please();
+
+			A.CallTo(() => requestBuilder.BuildRequest(A<RequestData>.That.Matches(x => x.TraceId == customTraceID))).MustHaveHappened();
+		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -29,7 +29,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 
 		private IRequestBuilder StubRequestBuilder()
 		{
-			var request = new Request(HttpMethod.Get, "http://example.com/status", new Dictionary<string, string>(), null);
+			var request = new Request(HttpMethod.Get, "http://example.com/status", new Dictionary<string, string>(), null, null);
 			var requestBuilder = A.Fake<IRequestBuilder>();
 			A.CallTo(() => requestBuilder.BuildRequest(A<RequestData>.Ignored)).Returns(request);
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
@@ -56,10 +56,10 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				}
 			};
 
-			var result1 = _requestBuilder.BuildRequest(endPointState);
-			var result2 = _requestBuilder.BuildRequest(endPointState);
+			var request1 = _requestBuilder.BuildRequest(endPointState);
+			var request2 = _requestBuilder.BuildRequest(endPointState);
 
-			Assert.That(result1.Url, Is.EqualTo(result2.Url));
+			Assert.That(request1.Url, Is.EqualTo(request2.Url));
 		}
 
 		[Test]
@@ -78,9 +78,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				Headers = new Dictionary<string, string>()
 			};
 
-			var response = _requestBuilder.BuildRequest(requestData);
+			var request = _requestBuilder.BuildRequest(requestData);
 
-			Assert.That(response.Url, Is.StringStarting(expectedApiUri));
+			Assert.That(request.Url, Is.StringStarting(expectedApiUri));
 		}
 
 		[Test]
@@ -96,9 +96,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				HttpMethod = HttpMethod.Post
 			};
 
-			var buildRequest = _requestBuilder.BuildRequest(requestData);
-			Assert.That(buildRequest.Body.Data, Is.EqualTo(parameters.ToQueryString()));
-			Assert.That(buildRequest.Body.ContentType, Is.EqualTo("application/x-www-form-urlencoded"));
+			var request = _requestBuilder.BuildRequest(requestData);
+			Assert.That(request.Body.Data, Is.EqualTo(parameters.ToQueryString()));
+			Assert.That(request.Body.ContentType, Is.EqualTo("application/x-www-form-urlencoded"));
 		}
 
 		[Test]
@@ -115,9 +115,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				Payload = new RequestPayload("text/plain", "I am a payload")
 			};
 
-			var buildRequest = _requestBuilder.BuildRequest(requestData);
-			Assert.That(buildRequest.Body.Data, Is.EqualTo(parameters.ToQueryString()));
-			Assert.That(buildRequest.Body.ContentType, Is.EqualTo("application/x-www-form-urlencoded"));
+			var request = _requestBuilder.BuildRequest(requestData);
+			Assert.That(request.Body.Data, Is.EqualTo(parameters.ToQueryString()));
+			Assert.That(request.Body.ContentType, Is.EqualTo("application/x-www-form-urlencoded"));
 		}
 
 		[Test]
@@ -129,9 +129,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				Payload = new RequestPayload("text/plain", "I am a payload")
 			};
 
-			var buildRequest = _requestBuilder.BuildRequest(requestData);
-			Assert.That(buildRequest.Body.Data, Is.EqualTo("I am a payload"));
-			Assert.That(buildRequest.Body.ContentType, Is.EqualTo("text/plain"));
+			var request = _requestBuilder.BuildRequest(requestData);
+			Assert.That(request.Body.Data, Is.EqualTo("I am a payload"));
+			Assert.That(request.Body.ContentType, Is.EqualTo("text/plain"));
 		}
 
 		[Test]
@@ -149,9 +149,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				BaseUriProvider = baseUriProvider
 			};
 
-			var response = _requestBuilder.BuildRequest(requestData);
+			var request = _requestBuilder.BuildRequest(requestData);
 
-			Assert.That(response.Url, Is.StringStarting(expectedApiUri));
+			Assert.That(request.Url, Is.StringStarting(expectedApiUri));
 		}
 
 		[Test]
@@ -168,9 +168,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 				Headers = new Dictionary<string, string>(),
 				BaseUriProvider = baseUriProvider
 			};
-			var response = _requestBuilder.BuildRequest(requestData);
+			var request = _requestBuilder.BuildRequest(requestData);
 
-			var traceIdHeader = response.Headers["x-7d-traceid"];
+			var traceIdHeader = request.Headers["x-7d-traceid"];
 			Assert.That(traceIdHeader, Is.Not.Null);
 			Assert.DoesNotThrow(() => Guid.Parse(traceIdHeader));
 		}

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
@@ -174,5 +174,29 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			Assert.That(traceIdHeader, Is.Not.Null);
 			Assert.DoesNotThrow(() => Guid.Parse(traceIdHeader));
 		}
+
+		[Test]
+		public void Should_allow_a_custom_traceId_to_be_specified()
+		{
+			const string expectedApiUri = "http://api.7dizzle";
+			var baseUriProvider = A.Fake<IBaseUriProvider>();
+			A.CallTo(() => baseUriProvider.BaseUri(A<RequestData>.Ignored)).Returns(expectedApiUri);
+
+			const string customTraceId = "Immagonnatrace4you";
+
+			var requestData = new RequestData
+			{
+				Endpoint = "test",
+				HttpMethod = HttpMethod.Get,
+				Headers = new Dictionary<string, string>(),
+				BaseUriProvider = baseUriProvider,
+				TraceId = customTraceId
+			};
+			var request = _requestBuilder.BuildRequest(requestData);
+
+			var traceIdHeader = request.Headers["x-7d-traceid"];
+			Assert.That(traceIdHeader, Is.Not.Null);
+			Assert.That(traceIdHeader, Is.EqualTo(customTraceId));
+		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using FakeItEasy;
 using NUnit.Framework;
@@ -151,6 +152,27 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var response = _requestBuilder.BuildRequest(requestData);
 
 			Assert.That(response.Url, Is.StringStarting(expectedApiUri));
+		}
+
+		[Test]
+		public void Should_add_traceId_header_as_a_valid_guid()
+		{
+			const string expectedApiUri = "http://api.7dizzle";
+			var baseUriProvider = A.Fake<IBaseUriProvider>();
+			A.CallTo(() => baseUriProvider.BaseUri(A<RequestData>.Ignored)).Returns(expectedApiUri);
+
+			var requestData = new RequestData
+			{
+				Endpoint = "test",
+				HttpMethod = HttpMethod.Get,
+				Headers = new Dictionary<string, string>(),
+				BaseUriProvider = baseUriProvider
+			};
+			var response = _requestBuilder.BuildRequest(requestData);
+
+			var traceIdHeader = response.Headers["x-7d-traceid"];
+			Assert.That(traceIdHeader, Is.Not.Null);
+			Assert.DoesNotThrow(() => Guid.Parse(traceIdHeader));
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/CacheHeaderReaderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/CacheHeaderReaderTests.cs
@@ -152,7 +152,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 		{
 			var requestHeaders = new Dictionary<string, string>();
 			var request = new Request(method, "http://some.url.com/foo/bar", requestHeaders,
-				new RequestPayload(string.Empty, string.Empty));
+				new RequestPayload(string.Empty, string.Empty), null);
 			return request;
 		}
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/InMemoryResponseCacheTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Responses/Parsing/InMemoryResponseCacheTests.cs
@@ -79,7 +79,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Responses.Parsing
 		{
 			var requestHeaders = new Dictionary<string, string>();
 			var request = new Request(HttpMethod.Get, "http://some.url.com/foo/" + suffix, requestHeaders,
-				new RequestPayload(string.Empty, string.Empty));
+				new RequestPayload(string.Empty, string.Empty), null);
 			return request;
 		}
 

--- a/src/SevenDigital.Api.Wrapper/FluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/FluentApi.cs
@@ -96,6 +96,17 @@ namespace SevenDigital.Api.Wrapper
 			return this;
 		}
 
+		public IFluentApi<T> WithTraceId(string traceId)
+		{
+			if (string.IsNullOrEmpty(traceId))
+			{
+				throw new ArgumentNullException("traceId");
+			}
+
+			_requestData.TraceId = traceId;
+			return this;
+		}
+
 		public IFluentApi<T> WithParameter(string parameterName, string parameterValue)
 		{
 			_requestData.Parameters[parameterName] = parameterValue;

--- a/src/SevenDigital.Api.Wrapper/IFluentApi.cs
+++ b/src/SevenDigital.Api.Wrapper/IFluentApi.cs
@@ -19,6 +19,7 @@ namespace SevenDigital.Api.Wrapper
 	
 		IFluentApi<T> WithMethod(HttpMethod httpMethod);
 		IFluentApi<T> WithAccept(AcceptFormat acceptFormat);
+		IFluentApi<T> WithTraceId(string traceId);
 
 		IFluentApi<T> WithPayload<TPayload>(TPayload payload) where TPayload : class;
 		IFluentApi<T> WithPayload<TPayload>(TPayload payload, PayloadFormat payloadSerializer) where TPayload : class;

--- a/src/SevenDigital.Api.Wrapper/Requests/Request.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/Request.cs
@@ -9,12 +9,13 @@ namespace SevenDigital.Api.Wrapper.Requests
 	[Serializable]
 	public class Request : ISerializable
 	{
-		public Request(HttpMethod method, string url, IDictionary<string, string> headers, RequestPayload body)
+		public Request(HttpMethod method, string url, IDictionary<string, string> headers, RequestPayload body, string traceId)
 		{
 			Method = method;
 			Url = url;
 			Headers = headers;
 			Body = body;
+			TraceId = traceId;
 		}
 
 		public Request(SerializationInfo info, StreamingContext context)
@@ -23,6 +24,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 			Url = info.GetString("Url");
 			Body = (RequestPayload)info.GetValue("Body", typeof(RequestPayload));
 			Headers = (IDictionary<string, string>)info.GetValue("Headers", typeof(IDictionary<string, string>));
+			TraceId = info.GetString("TraceId");
 		}
 
 		public HttpMethod Method { get; private set; }
@@ -30,6 +32,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 		public string Url { get; private set; }
 		public IDictionary<string, string> Headers { get; private set; }
 		public RequestPayload Body { get; private set; }
+		public string TraceId { get; private set; }
 
 		/// <summary>
 		/// we need to override serialisation as 'System.Net.Http.HttpMethod' is not a serializable type
@@ -42,6 +45,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 			info.AddValue("Url", Url, typeof(string));
 			info.AddValue("Body", Body);
 			info.AddValue("Headers", Headers);
+			info.AddValue("TraceId", TraceId);
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
@@ -39,7 +39,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 				fullUrl += "?" + apiRequest.Parameters.ToQueryString();
 			}
 
-			return new Request(requestData.HttpMethod, fullUrl, headers, requestBody);
+			return new Request(requestData.HttpMethod, fullUrl, headers, requestBody, requestData.TraceId);
 		}
 
 		private static RequestPayload CheckForRequestPayload(RequestData requestData, IDictionary<string,string> requestParameters)

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Web;
 using OAuth;
@@ -31,12 +32,12 @@ namespace SevenDigital.Api.Wrapper.Requests
 			var oauthHeader = GetAuthorizationHeader(requestData, fullUrl, apiRequest, requestBody);
 			headers.Add("Authorization", oauthHeader);
 			headers.Add("Accept", requestData.Accept);
+			headers.Add("x-7d-traceid", Guid.NewGuid().ToString());
 
 			if (requestData.HttpMethod.HasParamsInQueryString() && (apiRequest.Parameters.Count > 0))
 			{
 				fullUrl += "?" + apiRequest.Parameters.ToQueryString();
 			}
-
 
 			return new Request(requestData.HttpMethod, fullUrl, headers, requestBody);
 		}

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
@@ -32,14 +32,16 @@ namespace SevenDigital.Api.Wrapper.Requests
 			var oauthHeader = GetAuthorizationHeader(requestData, fullUrl, apiRequest, requestBody);
 			headers.Add("Authorization", oauthHeader);
 			headers.Add("Accept", requestData.Accept);
-			headers.Add("x-7d-traceid", requestData.TraceId);
+
+			var traceId = requestData.TraceId ?? Guid.NewGuid().ToString();
+			headers.Add("x-7d-traceid", traceId);
 
 			if (requestData.HttpMethod.HasParamsInQueryString() && (apiRequest.Parameters.Count > 0))
 			{
 				fullUrl += "?" + apiRequest.Parameters.ToQueryString();
 			}
 
-			return new Request(requestData.HttpMethod, fullUrl, headers, requestBody, requestData.TraceId);
+			return new Request(requestData.HttpMethod, fullUrl, headers, requestBody, traceId);
 		}
 
 		private static RequestPayload CheckForRequestPayload(RequestData requestData, IDictionary<string,string> requestParameters)

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
@@ -32,7 +32,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 			var oauthHeader = GetAuthorizationHeader(requestData, fullUrl, apiRequest, requestBody);
 			headers.Add("Authorization", oauthHeader);
 			headers.Add("Accept", requestData.Accept);
-			headers.Add("x-7d-traceid", Guid.NewGuid().ToString());
+			headers.Add("x-7d-traceid", requestData.TraceId);
 
 			if (requestData.HttpMethod.HasParamsInQueryString() && (apiRequest.Parameters.Count > 0))
 			{

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestData.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestData.cs
@@ -38,7 +38,6 @@ namespace SevenDigital.Api.Wrapper.Requests
 			Headers = new Dictionary<string,string>();
 			UseHttps = false;
 			Accept = "application/xml";
-			TraceId = Guid.NewGuid().ToString();
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestData.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace SevenDigital.Api.Wrapper.Requests
@@ -25,6 +26,8 @@ namespace SevenDigital.Api.Wrapper.Requests
 
 		public string Accept { get; set; }
 
+		public string TraceId { get; set; }
+
 		public IBaseUriProvider BaseUriProvider { get; set; }
 
 		public RequestData()
@@ -35,6 +38,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 			Headers = new Dictionary<string,string>();
 			UseHttps = false;
 			Accept = "application/xml";
+			TraceId = Guid.NewGuid().ToString();
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Responses/Response.cs
+++ b/src/SevenDigital.Api.Wrapper/Responses/Response.cs
@@ -39,12 +39,12 @@ namespace SevenDigital.Api.Wrapper.Responses
 		{
 			const string ContentTypeHeaderKey = "Content-Type";
 			if (!Headers.ContainsKey(ContentTypeHeaderKey))
- 			{
- 				return false;
- 			}
+			{
+				return false;
+			}
 
 			var contentType = Headers[ContentTypeHeaderKey];
- 			return contentType.StartsWith("application/json") || contentType.StartsWith("text/json");
- 		}
+			return contentType.StartsWith("application/json") || contentType.StartsWith("text/json");
+		}
 	}
 }


### PR DESCRIPTION
as outlined in 7dig Logging TraceIds Api standards (https://sites.google.com/a/7digital.com/teams/technology/api-standards/traceids)

I've basically just added the header to RequestBuilder and enforced a Guid every time. There is no opt in / opt out, it will start sending for all requests from the api wrapper as soon as it the version containing it is used in a consuming app.

Is this correct? I can't see any reason why it should be optional, can anyone else?
