### PR TITLE
Update Api.Schema library to v1.4.1

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/SevenDigital.Api.Wrapper.Integration.Tests.csproj
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.3.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.4.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/packages.config
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.3.1" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.4.1" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/FluentAPITests.cs
@@ -329,7 +329,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests
 		[Test]
 		public async void Should_allow_you_to_set_a_request_payload_using_an_entity_transferred_as_json()
 		{
-			const string expectedOutput = "{\"id\":143451,\"name\":\"MGMT\",\"sortName\":null,\"appearsAs\":\"MGMT\",\"image\":\"http://cdn.7static.com/static/img/artistimages/00/001/434/0000143451_150.jpg\",\"url\":\"http://www.7digital.com/artist/mgmt/?partner=1401\"}";
+			const string expectedOutput = "{\"id\":143451,\"name\":\"MGMT\",\"sortName\":null,\"appearsAs\":\"MGMT\",\"image\":\"http://cdn.7static.com/static/img/artistimages/00/001/434/0000143451_150.jpg\",\"url\":\"http://www.7digital.com/artist/mgmt/?partner=1401\",\"slug\":null}";
 			
 			var artist = new Artist
 			{

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/JsonPayloadSerializerTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/Serializing/JsonPayloadSerializerTests.cs
@@ -18,7 +18,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests.Serializing
 		[Test]
 		public void Should_serialize_artist_as_expected()
 		{
-			const string expected = "{\"id\":143451,\"name\":\"MGMT\",\"sortName\":null,\"appearsAs\":\"MGMT\",\"image\":\"http://cdn.7static.com/static/img/artistimages/00/001/434/0000143451_150.jpg\",\"url\":\"http://www.7digital.com/artist/mgmt/?partner=1401\"}";
+			const string expected = "{\"id\":143451,\"name\":\"MGMT\",\"sortName\":null,\"appearsAs\":\"MGMT\",\"image\":\"http://cdn.7static.com/static/img/artistimages/00/001/434/0000143451_150.jpg\",\"url\":\"http://www.7digital.com/artist/mgmt/?partner=1401\",\"slug\":null}";
 			
 			var artist = new Artist
 				{

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/SevenDigital.Api.Wrapper.Unit.Tests.csproj
@@ -50,7 +50,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.3.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.4.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/packages.config
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/packages.config
@@ -3,5 +3,5 @@
   <package id="FakeItEasy" version="1.25.3" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.3.1" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.4.1" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -45,7 +45,7 @@
       <HintPath>..\..\packages\OAuth.1.0.3\lib\net40\OAuth.dll</HintPath>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.3.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\..\packages\SevenDigital.Api.Schema.1.4.1\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/SevenDigital.Api.Wrapper/packages.config
+++ b/src/SevenDigital.Api.Wrapper/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
   <package id="OAuth" version="1.0.3" targetFramework="net40" />
-  <package id="SevenDigital.Api.Schema" version="1.3.1" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.4.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Pretty straightforward, just updates the dependency on Api.Schema to 1.4.1 and fixes a couple of tests that rely on a new property to be serialized, even if it's null (`slug`). 