### PR TITLE
Remove mutation that was adding extra query params

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ApiSetupCredentialPassingTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/ApiSetupCredentialPassingTests.cs
@@ -20,7 +20,7 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests
 
 		public IFluentApi<T> Create<T>() where T : class, new()
 		{
-			return new FluentApi<T>(new HttpClientMediator(), new RequestBuilder(_apiUrl, _credentials), new ResponseParser(new ApiResponseDetector()));
+			return new FluentApi<T>(new HttpClientMediator(), new RequestBuilder(new RouteParamsSubstitutor(_apiUrl), _credentials), new ResponseParser(new ApiResponseDetector()));
 		}
 	}
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderMethodTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderMethodTests.cs
@@ -25,7 +25,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			A.CallTo(() => _oAuthCredentials.ConsumerKey).Returns("testkey");
 			A.CallTo(() => _oAuthCredentials.ConsumerSecret).Returns("testsecret");
 
-			_requestBuilder = new RequestBuilder(_apiUri, _oAuthCredentials);
+			_requestBuilder = new RequestBuilder(new RouteParamsSubstitutor(_apiUri), _oAuthCredentials);
 		}
 
 		[TestCase]

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderOAuthHeaderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderOAuthHeaderTests.cs
@@ -15,7 +15,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		{
 			var appSettingsCredentials = new StubbedConsumerCreds();
 			var apiUri = new ApiUri();
-			_requestBuilder = new RequestBuilder(apiUri, appSettingsCredentials);
+			_requestBuilder = new RequestBuilder(new RouteParamsSubstitutor(apiUri), appSettingsCredentials);
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper/Api.cs
+++ b/src/SevenDigital.Api.Wrapper/Api.cs
@@ -22,7 +22,7 @@ namespace SevenDigital.Api.Wrapper
 
 		public IFluentApi<T> Create<T>() where T : class, new()
 		{
-			return new FluentApi<T>(new HttpClientMediator(), new RequestBuilder(_apiUri, _oauthCredentials), new ResponseParser(new ApiResponseDetector()));
+			return new FluentApi<T>(new HttpClientMediator(), new RequestBuilder(new RouteParamsSubstitutor(_apiUri), _oauthCredentials), new ResponseParser(new ApiResponseDetector()));
 		}
 	}
 }

--- a/src/SevenDigital.Api.Wrapper/Requests/IRouteParamsSubstitutor.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/IRouteParamsSubstitutor.cs
@@ -1,0 +1,7 @@
+namespace SevenDigital.Api.Wrapper.Requests
+{
+	public interface IRouteParamsSubstitutor
+	{
+		ApiRequest SubstituteParamsInRequest(RequestData requestData);
+	}
+}

--- a/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
@@ -5,7 +5,7 @@ using System.Text.RegularExpressions;
 
 namespace SevenDigital.Api.Wrapper.Requests
 {
-	public class RouteParamsSubstitutor
+	public class RouteParamsSubstitutor : IRouteParamsSubstitutor
 	{
 		private readonly IBaseUriProvider _defaultBaseUriProvider;
 

--- a/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
+++ b/src/SevenDigital.Api.Wrapper/SevenDigital.Api.Wrapper.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Requests\BaseUriFromString.cs" />
     <Compile Include="Requests\IBaseUriProvider.cs" />
     <Compile Include="Requests\IRequestBuilder.cs" />
+    <Compile Include="Requests\IRouteParamsSubstitutor.cs" />
     <Compile Include="Requests\RequestBuilder.cs" />
     <Compile Include="Requests\RequestPayload.cs" />
     <Compile Include="Requests\RouteParamsSubstitutor.cs" />


### PR DESCRIPTION
POST endpoints with parameter substitution e.g. ~/foo/{bar} are not working after v7.  The user is told that query string parameters cannot be used in combination with payloads, even if the parameter is substituted into the url.

 I tracked this down to unintentional mutation in the RequestBuilder.BuildOAuthHeader method, which was adding the substitution parameters back in to the query string parameters after they had been removed.

I've fixed the mutation and renamed a couple of variables to make it a little clearer.