### PR TITLE
Post params no qs

### DIFF
--- a/examples/ExampleUsage/ExampleUsage/App.config
+++ b/examples/ExampleUsage/ExampleUsage/App.config
@@ -1,8 +1,8 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <add key="Wrapper.ConsumerKey" value="YOUR_KEY_HERE" />
-    <add key="Wrapper.ConsumerSecret" value="" />
+    <add key="Wrapper.ConsumerSecret" value="YOUR_SECRET_HERE" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
   </appSettings>
   <startup>
@@ -20,4 +20,12 @@
       </providers>
     </roleManager>
   </system.web>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/examples/ExampleUsage/ExampleUsage/Program.cs
+++ b/examples/ExampleUsage/ExampleUsage/Program.cs
@@ -57,8 +57,7 @@ namespace SevenDigital.Api.Wrapper.ExampleUsage
 
 			// -- artist/browse
 			const string searchValue = "Radio";
-			var artistBrowse = await Api<ArtistBrowse>
-				.Create
+			var artistBrowse = await api.Create<ArtistBrowse>()
 				.WithLetter(searchValue)
 				.Please();
 
@@ -88,31 +87,33 @@ namespace SevenDigital.Api.Wrapper.ExampleUsage
 			await DoParalellSearches(api, searchValue);
 
 			// -- Debug uri
-		string currentUri = api.Create<ReleaseSearch>()
+			string currentUri = api.Create<ReleaseSearch>()
 				.WithQuery("Test").EndpointUrl;
 			Console.WriteLine("Release search hits: {0}", currentUri);
+			Console.WriteLine();
 
 			try
 			{
 				// -- Deliberate error response
-				Console.WriteLine("Trying artist/details without artistId parameter...");
+				Console.WriteLine("Trying to request artist/details without artistId parameter...");
 				await api.Create<Artist>().Please();
 			}
-
 			catch (ApiResponseException ex)
 			{
-				Console.WriteLine("{0} : {1}", ex, ex.Message);
+				Console.WriteLine("ERROR: {0}", ex.Message);
+				Console.WriteLine();
 			}
 
 			try
 			{
 				// -- Deliberate unauthorized response
-				Console.WriteLine("Trying user/locker without any credentials...");
+				Console.WriteLine("Trying to access user/locker without an authenticated user access token...");
 				await api.Create<Locker>().Please();
 			}
-			catch (ArgumentException ex)
+			catch (ApiResponseException ex)
 			{
-				Console.WriteLine("{0} : {1}", ex, ex.Message);
+				Console.WriteLine("ERROR: {0}", ex.Message);
+				Console.WriteLine();
 			}
 		}
 

--- a/examples/ExampleUsage/ExampleUsage/SevenDigital.Api.Wrapper.ExampleUsage.csproj
+++ b/examples/ExampleUsage/ExampleUsage/SevenDigital.Api.Wrapper.ExampleUsage.csproj
@@ -55,21 +55,21 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="OAuth, Version=1.0.0.0, Culture=neutral, PublicKeyToken=75b3c62967edc2a2, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\OAuth.1.0.3\lib\net40\OAuth.dll</HintPath>
     </Reference>
     <Reference Include="SevenDigital.Api.Schema, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SevenDigital.Api.Schema.1.0.0\lib\portable-net4+sl4+wp71+windows8\SevenDigital.Api.Schema.dll</HintPath>
+      <HintPath>..\packages\SevenDigital.Api.Schema.1.4.2\lib\net40\SevenDigital.Api.Schema.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="SevenDigital.Api.Wrapper, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\SevenDigital.Api.Wrapper.5.0.0\lib\net45\SevenDigital.Api.Wrapper.dll</HintPath>
+      <HintPath>..\packages\SevenDigital.Api.Wrapper.7.0.0\lib\net45\SevenDigital.Api.Wrapper.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />

--- a/examples/ExampleUsage/ExampleUsage/packages.config
+++ b/examples/ExampleUsage/ExampleUsage/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net45" />
   <package id="OAuth" version="1.0.3" targetFramework="net45" />
-  <package id="SevenDigital.Api.Schema" version="1.0.0" targetFramework="net45" />
-  <package id="SevenDigital.Api.Wrapper" version="5.0.0" targetFramework="net45" />
+  <package id="SevenDigital.Api.Schema" version="1.4.2" targetFramework="net45" />
+  <package id="SevenDigital.Api.Wrapper" version="7.0.0" targetFramework="net45" />
 </packages>

--- a/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/OAuth/OAuthRequestTokenTest.cs
+++ b/src/SevenDigital.Api.Wrapper.Integration.Tests/EndpointTests/OAuth/OAuthRequestTokenTest.cs
@@ -39,6 +39,16 @@ namespace SevenDigital.Api.Wrapper.Integration.Tests.EndpointTests.OAuth
 		}
 
 		[Test]
+		public void POSTing_with_data_should_not_append_to_qs_and_should_therefore_not_throw_error()
+		{
+			var api = (FluentApi<OAuthRequestToken>)Api<OAuthRequestToken>.Create;
+
+			api.WithMethod(HttpMethod.Post);
+			api.WithParameter("test", "value");
+			Assert.DoesNotThrow(async () => await api.Please());
+		}
+
+		[Test]
 		public async void Can_handle_odd_characters_in_get_signing_process()
 		{
 			var oAuthRequestToken = await Api<OAuthRequestToken>

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderMethodTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderMethodTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Net.Http;
 using FakeItEasy;
 using NUnit.Framework;
-using SevenDigital.Api.Wrapper.Http;
 using SevenDigital.Api.Wrapper.Requests;
+using SevenDigital.Api.Wrapper.Http;
 
 namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 {
@@ -59,8 +59,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		}
 
 		[TestCase]
-		public void Should_include_parameters_in_querystring()
+		public void Should_include_parameters_in_querystring_when_applicable()
 		{
+			if (TestedHttpMethod.ShouldHaveRequestBody())
+			{
+				Assert.Pass("Test only applicable to method that does not require request body");
+			}
 			var requestData = MakeRequestData(TestedHttpMethod, false);
 			requestData.Parameters.Add("foo", "bar");
 
@@ -70,8 +74,12 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		}
 
 		[TestCase]
-		public void Should_include_parameters_in_querystring_when_signed()
+		public void Should_include_parameters_in_querystring_when_signed_when_applicable()
 		{
+			if (TestedHttpMethod.ShouldHaveRequestBody())
+			{
+				Assert.Pass("Test only applicable to method that does not require request body");
+			}
 			var requestData = MakeRequestData(TestedHttpMethod, true);
 			requestData.Parameters.Add("foo", "bar");
 

--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RequestBuilderTests.cs
@@ -84,7 +84,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		}
 
 		[Test]
-		public void Post_data_with_params_defaults_to_params()
+		public void Post_data_with_params_defaults_to_form_urlencoded_payload()
 		{
 			var parameters = new Dictionary<string, string>
 			{
@@ -97,7 +97,9 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			};
 
 			var request = _requestBuilder.BuildRequest(requestData);
-			Assert.That(request.Url, Is.StringContaining("?one=foo"));
+			Assert.That(request.Url, Is.Not.StringContaining("?one=foo"));
+			Assert.That(request.Body.Data, Is.StringContaining("one=foo"));
+			Assert.That(request.Body.ContentType, Is.StringContaining("application/x-www-form-urlencoded"));
 		}
 
 		[Test]
@@ -115,7 +117,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			};
 
 			var request = _requestBuilder.BuildRequest(requestData);
-			Assert.That(request.Url, Is.StringContaining("?one=foo"));
+			Assert.That(request.Url, Is.Not.StringContaining("?one=foo"));
 			Assert.That(request.Body.Data, Is.EqualTo(requestData.Payload.Data));
 			Assert.That(request.Body.ContentType, Is.EqualTo("text/plain"));
 		}

--- a/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RequestBuilder.cs
@@ -36,7 +36,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 			var traceId = requestData.TraceId ?? Guid.NewGuid().ToString();
 			headers.Add("x-7d-traceid", traceId);
 
-			if (apiRequest.Parameters.Count > 0)
+			if (apiRequest.Parameters.Count > 0 && !requestData.HttpMethod.ShouldHaveRequestBody())
 			{
 				fullUrl += "?" + apiRequest.Parameters.ToQueryString();
 			}
@@ -72,14 +72,13 @@ namespace SevenDigital.Api.Wrapper.Requests
 			var httpMethod = requestData.HttpMethod.ToString().ToUpperInvariant();
 
 			var oauthRequest = new OAuthRequest
-				{
-					Type = OAuthRequestType.ProtectedResource,
-					RequestUrl = fullUrl,
-					Method = httpMethod,
-					ConsumerKey = _oAuthCredentials.ConsumerKey,
-					ConsumerSecret = _oAuthCredentials.ConsumerSecret,
-					
-				};
+			{
+				Type = OAuthRequestType.ProtectedResource,
+				RequestUrl = fullUrl,
+				Method = httpMethod,
+				ConsumerKey = _oAuthCredentials.ConsumerKey,
+				ConsumerSecret = _oAuthCredentials.ConsumerSecret,
+			};
 
 			if (!string.IsNullOrEmpty(requestData.OAuthToken))
 			{


### PR DESCRIPTION
This relates to issue #237 

It ensures that params aren't appended to the qs if the request httpMethod `SHouldHaveRequestBody` as the api rejects any POST request with qs params

It also contains a dep update and some changes to the example code to make error messages less confusing