### PR TITLE
Change URL behaviour to match W3 spec

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RouteParamsSubstitutorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RouteParamsSubstitutorTests.cs
@@ -15,7 +15,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		public void Setup()
 		{
 			_apiUri = A.Fake<IApiUri>();
-			A.CallTo(() => _apiUri.Uri).Returns("http://example.com");
+			A.CallTo(() => _apiUri.Uri).Returns("http://EXAMPLE.com");
 			A.CallTo(() => _apiUri.SecureUri).Returns("https://example.com");
 		}
 
@@ -59,7 +59,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		{
 			var requestData = new RequestData
 			{
-				Endpoint = "something/{firstRoute}/{secondRoute}/thrid/{thirdRoute}",
+				Endpoint = "something/{firstRoute}/{secondRoute}/third/{thirdRoute}",
 				Parameters = new Dictionary<string, string>
 					{
 						{"firstRoute" , "firstValue"},
@@ -72,15 +72,15 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstValue/secondValue/third/thirdValue"));
 		}
 
 		[Test]
-		public void Routes_should_be_case_insensitive()
+		public void Domain_should_be_case_insensitive_routes_should_be_case_sensitive()
 		{
 			var requestData = new RequestData
 			{
-				Endpoint = "something/{firstRoUte}/{secOndrouTe}/thrid/{tHirdRoute}",
+				Endpoint = "someThing/{firstRoUte}/{secOndrouTe}/third/{tHirdRoute}",
 				Parameters = new Dictionary<string, string>
 					{
 						{"firstRoute" , "firstValue"},
@@ -93,7 +93,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
+			Assert.That(result.AbsoluteUrl, Is.EqualTo("http://example.com/someThing/firstValue/secondValue/third/thirdValue"));
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
@@ -33,7 +33,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 		{
 			var baseUriProvider = requestData.BaseUriProvider ?? _defaultBaseUriProvider;
 
-			return baseUriProvider.BaseUri(requestData);
+			return baseUriProvider.BaseUri(requestData).ToLower();
 		}
 
 		private static string SubstituteRouteParameters(string endpointUri, IDictionary<string, string> parameters)
@@ -48,7 +48,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 				endpointUri = endpointUri.Replace(match.ToString(), entry.Value);
 			}
 
-			return endpointUri.ToLower();
+			return endpointUri;
 		}
 	}
 }


### PR DESCRIPTION
We're attempting to make requests to an API that has case sensitive endpoints.  The current behaviour of the wrapper does the not match the W3 spec [1] which says that the domain name should be case insensitive, but the endpoint does not need to be case insensitive.  The wrapper currently lowercases the entire url.

Tests were added after the lowercase was a thing, so there's no record of why we're lower casing it all.  If this is going to break things we can try and get the endpoint fixed instead.

[1] http://stackoverflow.com/questions/7996919/should-url-be-case-sensitive