### PR TITLE
Revert "Change URL behaviour to match W3 spec"

### DIFF
--- a/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RouteParamsSubstitutorTests.cs
+++ b/src/SevenDigital.Api.Wrapper.Unit.Tests/Requests/RouteParamsSubstitutorTests.cs
@@ -15,7 +15,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		public void Setup()
 		{
 			_apiUri = A.Fake<IApiUri>();
-			A.CallTo(() => _apiUri.Uri).Returns("http://EXAMPLE.com");
+			A.CallTo(() => _apiUri.Uri).Returns("http://example.com");
 			A.CallTo(() => _apiUri.SecureUri).Returns("https://example.com");
 		}
 
@@ -59,7 +59,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 		{
 			var requestData = new RequestData
 			{
-				Endpoint = "something/{firstRoute}/{secondRoute}/third/{thirdRoute}",
+				Endpoint = "something/{firstRoute}/{secondRoute}/thrid/{thirdRoute}",
 				Parameters = new Dictionary<string, string>
 					{
 						{"firstRoute" , "firstValue"},
@@ -72,15 +72,15 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstValue/secondValue/third/thirdValue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
 
 		[Test]
-		public void Domain_should_be_case_insensitive_routes_should_be_case_sensitive()
+		public void Routes_should_be_case_insensitive()
 		{
 			var requestData = new RequestData
 			{
-				Endpoint = "someThing/{firstRoUte}/{secOndrouTe}/third/{tHirdRoute}",
+				Endpoint = "something/{firstRoUte}/{secOndrouTe}/thrid/{tHirdRoute}",
 				Parameters = new Dictionary<string, string>
 					{
 						{"firstRoute" , "firstValue"},
@@ -93,7 +93,7 @@ namespace SevenDigital.Api.Wrapper.Unit.Tests.Requests
 			var routeParamsSubstitutor = new RouteParamsSubstitutor(_apiUri);
 			var result = routeParamsSubstitutor.SubstituteParamsInRequest(requestData);
 
-			Assert.That(result.AbsoluteUrl, Is.EqualTo("http://example.com/someThing/firstValue/secondValue/third/thirdValue"));
+			Assert.That(result.AbsoluteUrl, Is.StringContaining("something/firstvalue/secondvalue/thrid/thirdvalue"));
 		}
 
 		[Test]

--- a/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
+++ b/src/SevenDigital.Api.Wrapper/Requests/RouteParamsSubstitutor.cs
@@ -33,7 +33,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 		{
 			var baseUriProvider = requestData.BaseUriProvider ?? _defaultBaseUriProvider;
 
-			return baseUriProvider.BaseUri(requestData).ToLower();
+			return baseUriProvider.BaseUri(requestData);
 		}
 
 		private static string SubstituteRouteParameters(string endpointUri, IDictionary<string, string> parameters)
@@ -48,7 +48,7 @@ namespace SevenDigital.Api.Wrapper.Requests
 				endpointUri = endpointUri.Replace(match.ToString(), entry.Value);
 			}
 
-			return endpointUri;
+			return endpointUri.ToLower();
 		}
 	}
 }


### PR DESCRIPTION
This reverts commit 4ca1b5494e45354301d8bc5acc33d66fadc6fc97.

This broke things when we upgraded.  We no longer need the functionality so probably easiest just to remove it.
